### PR TITLE
v0.8: Theme cycling, agent detail chat, non-blocking refresh

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod db;
+mod theme;
 
 use dotenvy;
 use crossterm::{
@@ -15,6 +16,9 @@ use serde::{Deserialize, Serialize};
 use std::io::stdout;
 use std::time::{Duration, Instant};
 use tokio::process::Command;
+use tokio::sync::mpsc;
+
+use theme::{BgDensity, Theme, ThemeName};
 
 // ---- Data ----
 
@@ -71,10 +75,18 @@ struct ChatLine {
 }
 
 #[derive(PartialEq, Clone)]
-enum Focus { Fleet, Chat }
+enum Focus { Fleet, Chat, AgentChat }
 
 #[derive(PartialEq)]
 enum Screen { Dashboard, AgentDetail, Help }
+
+struct ProbeResult {
+    index: usize,
+    status: AgentStatus,
+    os: String,
+    kernel: String,
+    oc_version: String,
+}
 
 struct App {
     agents: Vec<Agent>,
@@ -90,7 +102,15 @@ struct App {
     chat_input: String,
     chat_history: Vec<ChatLine>,
     chat_scroll: u16,
+    agent_chat_input: String,
+    agent_chat_scroll: u16,
+    refresh_rx: Option<mpsc::UnboundedReceiver<ProbeResult>>,
+    refreshing: bool,
     self_ip: String,
+    // Theme
+    theme_name: ThemeName,
+    bg_density: BgDensity,
+    theme: Theme,
 }
 
 impl App {
@@ -99,7 +119,6 @@ impl App {
         let self_ip = std::env::var("SAM_SELF_IP").unwrap_or_else(|_| "localhost".into());
         let mut agents = Vec::new();
 
-        // Load from DB, enriched with fleet.toml metadata
         match db::load_fleet(&pool).await {
             Ok(db_agents) => {
                 for da in db_agents {
@@ -135,18 +154,43 @@ impl App {
             Err(_) => vec![],
         };
 
+        let tn = ThemeName::Standard;
+        let bd = BgDensity::Dark;
+
         App {
             fleet_config: fleet_config.agent,
             agents, selected: 0, screen: Screen::Dashboard, focus: Focus::Fleet,
             should_quit: false, last_refresh: Instant::now(), last_chat_poll: Instant::now(),
-            status_message: "v0.7 │ Tab=switch focus │ ?=help".into(),
-            db_pool: Some(pool), chat_input: String::new(), chat_history, chat_scroll: 0,
-            self_ip,
+            status_message: String::new(),
+            db_pool: Some(pool),
+            chat_input: String::new(), chat_history, chat_scroll: 0,
+            agent_chat_input: String::new(), agent_chat_scroll: 0,
+            refresh_rx: None, refreshing: false, self_ip,
+            theme_name: tn, bg_density: bd, theme: Theme::resolve(tn, bd),
         }
     }
 
     fn next(&mut self) { if self.selected < self.agents.len() - 1 { self.selected += 1; } }
     fn previous(&mut self) { if self.selected > 0 { self.selected -= 1; } }
+
+    fn user(&self) -> String { std::env::var("SAM_USER").unwrap_or_else(|_| "nick".into()) }
+
+    fn cycle_theme(&mut self) {
+        self.theme_name = self.theme_name.next();
+        self.theme = Theme::resolve(self.theme_name, self.bg_density);
+    }
+
+    fn cycle_bg(&mut self) {
+        self.bg_density = self.bg_density.next();
+        self.theme = Theme::resolve(self.theme_name, self.bg_density);
+    }
+
+    fn agent_chat_lines(&self) -> Vec<ChatLine> {
+        let db_name = &self.agents[self.selected].db_name;
+        self.chat_history.iter().filter(|m| {
+            m.target.as_deref() == Some(db_name.as_str()) || m.sender == *db_name
+        }).cloned().collect()
+    }
 
     async fn send_message(&mut self) {
         if self.chat_input.trim().is_empty() { return; }
@@ -162,14 +206,31 @@ impl App {
         } else { (None, input.trim().to_string()) };
 
         self.chat_history.push(ChatLine {
-            sender: std::env::var("SAM_USER").unwrap_or_else(|_| "operator".into()), target: target.clone(), message: message.clone(),
+            sender: self.user(), target: target.clone(), message: message.clone(),
             response: None, time: now_str(), status: "pending".into(),
         });
 
         if let Some(pool) = &self.db_pool {
-            let _ = db::send_chat(pool, &std::env::var("SAM_USER").unwrap_or_else(|_| "operator".into()), target.as_deref(), &message).await;
+            let _ = db::send_chat(pool, &self.user(), target.as_deref(), &message).await;
         }
         self.chat_scroll = 0;
+    }
+
+    async fn send_agent_message(&mut self) {
+        if self.agent_chat_input.trim().is_empty() { return; }
+        let message = self.agent_chat_input.clone();
+        self.agent_chat_input.clear();
+        let target = self.agents[self.selected].db_name.clone();
+
+        self.chat_history.push(ChatLine {
+            sender: self.user(), target: Some(target.clone()), message: message.clone(),
+            response: None, time: now_str(), status: "pending".into(),
+        });
+
+        if let Some(pool) = &self.db_pool {
+            let _ = db::send_chat(pool, &self.user(), Some(&target), &message).await;
+        }
+        self.agent_chat_scroll = 0;
     }
 
     async fn poll_chat(&mut self) {
@@ -182,6 +243,53 @@ impl App {
                 }).collect();
             }
         }
+    }
+
+    fn start_refresh(&mut self) {
+        if self.refreshing { return; }
+        self.refreshing = true;
+        self.last_refresh = Instant::now();
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.refresh_rx = Some(rx);
+
+        for (i, a) in self.agents.iter().enumerate() {
+            let (host, user, sip) = (a.host.clone(), a.ssh_user.clone(), self.self_ip.clone());
+            let tx = tx.clone();
+            tokio::spawn(async move {
+                let (status, os, kern, oc) = probe_agent(&host, &user, &sip).await;
+                let _ = tx.send(ProbeResult { index: i, status, os, kernel: kern, oc_version: oc });
+            });
+        }
+    }
+
+    fn drain_refresh_results(&mut self) -> Vec<(usize, AgentStatus, String, String, String)> {
+        let mut updates = vec![];
+        if let Some(rx) = &mut self.refresh_rx {
+            while let Ok(r) = rx.try_recv() {
+                if r.index < self.agents.len() {
+                    self.agents[r.index].status = r.status.clone();
+                    if !r.os.is_empty() { self.agents[r.index].os = r.os.clone(); }
+                    if !r.kernel.is_empty() { self.agents[r.index].kernel = r.kernel.clone(); }
+                    if !r.oc_version.is_empty() { self.agents[r.index].oc_version = r.oc_version.clone(); }
+                    self.agents[r.index].last_seen = now_str();
+                    updates.push((r.index, r.status, r.os, r.kernel, r.oc_version));
+                }
+            }
+        }
+        if self.refreshing && self.last_refresh.elapsed() > Duration::from_secs(8) {
+            self.refreshing = false;
+        }
+        updates
+    }
+
+    fn update_status_bar(&mut self) {
+        let on = self.agents.iter().filter(|a| a.status == AgentStatus::Online).count();
+        let total = self.agents.len();
+        let refresh = if self.refreshing { " ⟳" } else { "" };
+        self.status_message = format!(
+            "v0.8 │ {}/{} online{} │ theme:{}/{} │ r=refresh b=bg c=color ?=help",
+            on, total, refresh, self.theme_name.label(), self.bg_density.label()
+        );
     }
 }
 
@@ -212,60 +320,81 @@ async fn probe_agent(host: &str, user: &str, self_ip: &str) -> (AgentStatus, Str
     }
 }
 
-async fn refresh_fleet(agents: &mut Vec<Agent>, pool: &Option<mysql_async::Pool>, self_ip: &str) {
-    let mut handles = vec![];
-    for a in agents.iter() {
-        let (h, u, sip) = (a.host.clone(), a.ssh_user.clone(), self_ip.to_string());
-        handles.push(tokio::spawn(async move { probe_agent(&h, &u, &sip).await }));
-    }
-    for (i, handle) in handles.into_iter().enumerate() {
-        if let Ok((status, os, kern, oc)) = handle.await {
-            agents[i].status = status;
-            if !os.is_empty() { agents[i].os = os; }
-            if !kern.is_empty() { agents[i].kernel = kern; }
-            if !oc.is_empty() { agents[i].oc_version = oc; }
-            agents[i].last_seen = now_str();
-            if let Some(p) = pool {
-                let _ = db::update_agent_status(p, &agents[i].db_name, agents[i].status.to_db_str(),
-                    if agents[i].os.is_empty() { None } else { Some(&agents[i].os) },
-                    if agents[i].kernel.is_empty() { None } else { Some(&agents[i].kernel) },
-                    if agents[i].oc_version.is_empty() { None } else { Some(&agents[i].oc_version) },
-                ).await;
-            }
-        }
-    }
-}
-
 fn now_str() -> String {
     use std::process::Command as C;
     C::new("date").arg("+%H:%M:%S").output().map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string()).unwrap_or("now".into())
 }
 
-// ---- Colors ----
+// ---- Chat Line Rendering ----
 
-fn status_style(s: &AgentStatus) -> Style {
-    Style::default().fg(match s {
-        AgentStatus::Online => Color::Green, AgentStatus::Busy => Color::Yellow,
-        AgentStatus::Offline => Color::Red, AgentStatus::Probing => Color::Blue,
-        AgentStatus::Unknown => Color::DarkGray,
-    })
-}
-
-fn loc_style(l: &str) -> Style {
-    Style::default().fg(match l {
-        "Home" => Color::Rgb(100, 200, 100), "SM" => Color::Rgb(230, 180, 60),
-        "VPS" => Color::Rgb(180, 120, 220), "Mobile" => Color::Rgb(80, 180, 230),
-        _ => Color::White,
-    })
+fn build_chat_lines(messages: &[ChatLine], user: &str, t: &Theme) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if messages.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled("  No messages yet".to_string(), Style::default().fg(t.text_dim))));
+        return lines;
+    }
+    for msg in messages {
+        let ts = msg.target.as_ref().map(|t| format!("→@{}", t)).unwrap_or_else(|| "→all".into());
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {} ", msg.time), Style::default().fg(t.text_dim)),
+            Span::styled(msg.sender.clone(), Style::default().fg(
+                if msg.sender == user { t.sender_self } else { t.sender_other }
+            ).bold()),
+            Span::styled(format!(" {}", ts), Style::default().fg(t.text_dim)),
+        ]));
+        lines.push(Line::from(vec![
+            Span::raw("     "),
+            Span::styled(msg.message.clone(), Style::default().fg(t.text)),
+        ]));
+        if let Some(resp) = &msg.response {
+            let max_w = 50;
+            let words: Vec<&str> = resp.split_whitespace().collect();
+            let (mut cur, mut first) = (String::new(), true);
+            for w in &words {
+                if cur.len() + w.len() + 1 > max_w && !cur.is_empty() {
+                    let prefix = if first { "↳ ".to_string() } else { "  ".to_string() };
+                    lines.push(Line::from(vec![
+                        Span::raw("     "),
+                        Span::styled(prefix, Style::default().fg(t.sender_other)),
+                        Span::styled(cur.clone(), Style::default().fg(t.response)),
+                    ]));
+                    cur.clear(); first = false;
+                }
+                if !cur.is_empty() { cur.push(' '); }
+                cur.push_str(w);
+            }
+            if !cur.is_empty() {
+                let prefix = if first { "↳ ".to_string() } else { "  ".to_string() };
+                lines.push(Line::from(vec![
+                    Span::raw("     "),
+                    Span::styled(prefix, Style::default().fg(t.sender_other)),
+                    Span::styled(cur, Style::default().fg(t.response)),
+                ]));
+            }
+        } else if msg.status == "pending" {
+            lines.push(Line::from(vec![
+                Span::raw("     "),
+                Span::styled("⏳ awaiting response...".to_string(), Style::default().fg(t.pending)),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+    lines
 }
 
 // ---- Rendering ----
 
 fn render_dashboard(frame: &mut Frame, app: &App) {
+    let t = &app.theme;
     let outer = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(3), Constraint::Min(10), Constraint::Length(3)])
         .split(frame.area());
+
+    // Clear with bg color
+    let bg_block = Block::default().style(Style::default().bg(app.bg_density.bg()));
+    frame.render_widget(bg_block, frame.area());
 
     let online = app.agents.iter().filter(|a| a.status == AgentStatus::Online).count();
     let total = app.agents.len();
@@ -273,16 +402,21 @@ fn render_dashboard(frame: &mut Frame, app: &App) {
 
     let header = Paragraph::new(Line::from(vec![
         Span::raw("  "),
-        Span::styled("🛰️  S.A.M MISSION CONTROL", Style::default().fg(Color::Rgb(80, 200, 255)).bold()),
+        Span::styled("🛰️  S.A.M MISSION CONTROL", Style::default().fg(t.header_title).bold()),
         Span::raw("    "),
-        Span::styled(format!("{}", online), Style::default().fg(Color::Green).bold()),
-        Span::styled(format!("/{} agents", total), Style::default().fg(Color::DarkGray)),
+        Span::styled(format!("{}", online), Style::default().fg(t.status_online).bold()),
+        Span::styled(format!("/{} agents", total), Style::default().fg(t.text_dim)),
         Span::raw("    "),
-        Span::styled(if live { "● live" } else { "○ stale" }, Style::default().fg(if live { Color::Green } else { Color::Red })),
+        Span::styled(if live { "● live" } else { "○ stale" }, Style::default().fg(if live { t.status_online } else { t.status_offline })),
         Span::raw("    "),
-        Span::styled(match app.focus { Focus::Fleet => "▌Fleet▐", Focus::Chat => "▌Chat▐" }, Style::default().fg(Color::Rgb(80, 200, 255)).bold()),
+        Span::styled(if app.refreshing { "⟳ refreshing" } else { "" }, Style::default().fg(t.accent)),
+        Span::raw("    "),
+        Span::styled(match app.focus {
+            Focus::Fleet => "▌Fleet▐", Focus::Chat => "▌Chat▐", _ => "▌Fleet▐",
+        }, Style::default().fg(t.accent).bold()),
     ]))
-    .block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(Color::Rgb(60, 60, 80))));
+    .block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(t.border)).style(Style::default().bg(app.bg_density.bg())));
     frame.render_widget(header, outer[0]);
 
     let body = Layout::default()
@@ -290,23 +424,35 @@ fn render_dashboard(frame: &mut Frame, app: &App) {
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(outer[1]);
 
-    // Fleet
-    let fleet_active = app.focus == Focus::Fleet;
-    let fb = if fleet_active { Color::Rgb(80, 200, 255) } else { Color::Rgb(50, 50, 70) };
+    render_fleet_table(frame, app, body[0], app.focus == Focus::Fleet);
+    render_chat_panel(frame, app, body[1], app.focus == Focus::Chat, false);
+    render_footer(frame, app, outer[2]);
+}
+
+fn render_fleet_table(frame: &mut Frame, app: &App, area: Rect, active: bool) {
+    let t = &app.theme;
+    let fb = if active { t.border_active } else { t.border };
 
     let hcells = ["  ", "Agent", "Location", "Status", "Version"]
-        .iter().map(|h| Cell::from(*h).style(Style::default().fg(Color::Rgb(180, 180, 200)).bold()));
+        .iter().map(|h| Cell::from(*h).style(Style::default().fg(t.text_bold).bold()));
     let hrow = Row::new(hcells).height(1).bottom_margin(1);
 
     let rows: Vec<Row> = app.agents.iter().enumerate().map(|(i, a)| {
-        let sel = i == app.selected && fleet_active;
-        let bg = if sel { Color::Rgb(35, 40, 60) } else { Color::Reset };
+        let sel = i == app.selected && active;
+        let bg = if sel { t.selected_bg } else { app.bg_density.bg() };
+        let loc_color = match a.location.as_str() {
+            "Home" => t.loc_home, "SM" => t.loc_sm, "VPS" => t.loc_vps, "Mobile" => t.loc_mobile, _ => t.text,
+        };
+        let st_color = match a.status {
+            AgentStatus::Online => t.status_online, AgentStatus::Busy => t.status_busy,
+            AgentStatus::Offline => t.status_offline, _ => t.text_dim,
+        };
         Row::new(vec![
             Cell::from(format!(" {}", a.emoji)),
-            Cell::from(a.name.clone()).style(Style::default().fg(Color::White).bold()),
-            Cell::from(a.location.clone()).style(loc_style(&a.location)),
-            Cell::from(a.status.to_string()).style(status_style(&a.status)),
-            Cell::from(a.oc_version.clone()).style(Style::default().fg(Color::Rgb(120, 200, 220))),
+            Cell::from(a.name.clone()).style(Style::default().fg(t.text_bold).bold()),
+            Cell::from(a.location.clone()).style(Style::default().fg(loc_color)),
+            Cell::from(a.status.to_string()).style(Style::default().fg(st_color)),
+            Cell::from(a.oc_version.clone()).style(Style::default().fg(t.version)),
         ]).style(Style::default().bg(bg)).height(1)
     }).collect();
 
@@ -316,210 +462,206 @@ fn render_dashboard(frame: &mut Frame, app: &App) {
     ]).header(hrow)
     .block(Block::default().title(Span::styled(" Fleet ", Style::default().fg(fb).bold()))
         .borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(fb))
+        .style(Style::default().bg(app.bg_density.bg()))
         .padding(Padding::new(1, 1, 0, 0)));
-    frame.render_widget(table, body[0]);
+    frame.render_widget(table, area);
+}
 
-    // Chat
-    let chat_active = app.focus == Focus::Chat;
-    let cb = if chat_active { Color::Rgb(80, 200, 255) } else { Color::Rgb(50, 50, 70) };
+fn render_chat_panel(frame: &mut Frame, app: &App, area: Rect, active: bool, agent_mode: bool) {
+    let t = &app.theme;
+    let cb = if active { t.border_active } else { t.border };
 
     let cl = Layout::default().direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(3)])
-        .split(body[1]);
+        .split(area);
 
-    let mut lines: Vec<Line> = Vec::new();
-    if app.chat_history.is_empty() {
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled("  Type @agent message and press Enter", Style::default().fg(Color::Rgb(80, 80, 100)))));
-        lines.push(Line::from(Span::styled("  Example: @nix check disk space", Style::default().fg(Color::Rgb(60, 60, 80)))));
+    let (messages, scroll, input_text) = if agent_mode {
+        let msgs = app.agent_chat_lines();
+        let lines = build_chat_lines(&msgs, &app.user(), t);
+        (lines, app.agent_chat_scroll, &app.agent_chat_input)
     } else {
-        for msg in &app.chat_history {
-            let ts = msg.target.as_ref().map(|t| format!("→@{}", t)).unwrap_or_else(|| "→all".into());
-            lines.push(Line::from(vec![
-                Span::styled(format!("  {} ", msg.time), Style::default().fg(Color::Rgb(80, 80, 100))),
-                Span::styled(&msg.sender, Style::default().fg(if msg.sender == std::env::var("SAM_USER").unwrap_or_else(|_| "operator".into()) { Color::Rgb(230, 180, 60) } else { Color::Rgb(100, 220, 100) }).bold()),
-                Span::styled(format!(" {}", ts), Style::default().fg(Color::Rgb(80, 80, 120))),
-            ]));
-            lines.push(Line::from(vec![
-                Span::raw("     "),
-                Span::styled(&msg.message, Style::default().fg(Color::Rgb(220, 220, 230))),
-            ]));
-            if let Some(resp) = &msg.response {
-                let max_w = 50;
-                let words: Vec<&str> = resp.split_whitespace().collect();
-                let (mut cur, mut first) = (String::new(), true);
-                for w in words {
-                    if cur.len() + w.len() + 1 > max_w && !cur.is_empty() {
-                        lines.push(Line::from(vec![
-                            Span::raw("     "),
-                            if first { Span::styled("↳ ", Style::default().fg(Color::Rgb(100, 200, 100))) } else { Span::raw("  ") },
-                            Span::styled(cur.clone(), Style::default().fg(Color::Rgb(160, 210, 170))),
-                        ]));
-                        cur.clear(); first = false;
-                    }
-                    if !cur.is_empty() { cur.push(' '); }
-                    cur.push_str(w);
-                }
-                if !cur.is_empty() {
-                    lines.push(Line::from(vec![
-                        Span::raw("     "),
-                        if first { Span::styled("↳ ", Style::default().fg(Color::Rgb(100, 200, 100))) } else { Span::raw("  ") },
-                        Span::styled(cur, Style::default().fg(Color::Rgb(160, 210, 170))),
-                    ]));
-                }
-            } else if msg.status == "pending" {
-                lines.push(Line::from(vec![
-                    Span::raw("     "),
-                    Span::styled("⏳ awaiting response...", Style::default().fg(Color::Rgb(100, 100, 120))),
-                ]));
-            }
-            lines.push(Line::from(""));
-        }
-    }
+        let lines = build_chat_lines(&app.chat_history, &app.user(), t);
+        (lines, app.chat_scroll, &app.chat_input)
+    };
 
     let vh = cl[0].height.saturating_sub(2) as usize;
-    let tl = lines.len();
-    let scroll = if tl > vh && app.chat_scroll == 0 { (tl - vh) as u16 } else { app.chat_scroll };
+    let tl = messages.len();
+    let scroll_pos = if tl > vh && scroll == 0 { (tl - vh) as u16 } else { scroll };
 
-    let chat = Paragraph::new(lines).scroll((scroll, 0))
-        .block(Block::default().title(Span::styled(" Chat ", Style::default().fg(cb).bold()))
-            .borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(cb)));
+    let title = if agent_mode {
+        format!(" {} {} Chat ", app.agents[app.selected].emoji, app.agents[app.selected].name)
+    } else {
+        " Chat ".to_string()
+    };
+
+    let chat = Paragraph::new(messages).scroll((scroll_pos, 0))
+        .block(Block::default().title(Span::styled(title, Style::default().fg(cb).bold()))
+            .borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(cb))
+            .style(Style::default().bg(app.bg_density.bg())));
     frame.render_widget(chat, cl[0]);
 
-    let ib = if chat_active { Color::Rgb(80, 200, 255) } else { Color::Rgb(50, 50, 70) };
-    let input = Paragraph::new(Line::from(vec![
-        Span::styled(" › ", Style::default().fg(Color::Rgb(80, 200, 255))),
-        Span::styled(&app.chat_input, Style::default().fg(Color::White)),
-        if chat_active { Span::styled("▌", Style::default().fg(Color::Rgb(80, 200, 255))) } else { Span::raw("") },
-    ])).block(Block::default()
-        .title(if chat_active { " @agent message ⏎ " } else { " Tab to chat " })
-        .borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(ib)));
-    frame.render_widget(input, cl[1]);
+    let prompt = if agent_mode {
+        format!(" @{} › ", app.agents[app.selected].db_name)
+    } else if active {
+        " @agent message ⏎ ".to_string()
+    } else {
+        " Tab to chat ".to_string()
+    };
 
-    // Footer
-    let footer = Paragraph::new(Line::from(vec![
-        Span::raw("  "),
-        Span::styled(&app.status_message, Style::default().fg(Color::Rgb(140, 140, 160))),
-        Span::raw("    "),
-        Span::styled("Tab", Style::default().fg(Color::Rgb(80, 200, 255))),
-        Span::styled(" Focus  ", Style::default().fg(Color::Rgb(100, 100, 120))),
-        Span::styled("r", Style::default().fg(Color::Rgb(80, 200, 255))),
-        Span::styled(" Refresh  ", Style::default().fg(Color::Rgb(100, 100, 120))),
-        Span::styled("⏎", Style::default().fg(Color::Rgb(80, 200, 255))),
-        Span::styled(" Detail  ", Style::default().fg(Color::Rgb(100, 100, 120))),
-        Span::styled("?", Style::default().fg(Color::Rgb(80, 200, 255))),
-        Span::styled(" Help  ", Style::default().fg(Color::Rgb(100, 100, 120))),
-        Span::styled("q", Style::default().fg(Color::Rgb(80, 200, 255))),
-        Span::styled(" Quit", Style::default().fg(Color::Rgb(100, 100, 120))),
-    ])).block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(Color::Rgb(40, 40, 60))));
-    frame.render_widget(footer, outer[2]);
+    let input = Paragraph::new(Line::from(vec![
+        Span::styled(" › ", Style::default().fg(t.accent)),
+        Span::styled(input_text.as_str(), Style::default().fg(t.text)),
+        if active { Span::styled("▌", Style::default().fg(t.accent)) } else { Span::raw("") },
+    ])).block(Block::default().title(prompt)
+        .borders(Borders::ALL).border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(if active { t.border_active } else { t.border }))
+        .style(Style::default().bg(app.bg_density.bg())));
+    frame.render_widget(input, cl[1]);
 }
 
 fn render_detail(frame: &mut Frame, app: &App) {
+    let t = &app.theme;
     let a = &app.agents[app.selected];
     let chunks = Layout::default().direction(Direction::Vertical)
         .constraints([Constraint::Length(3), Constraint::Min(10), Constraint::Length(3)])
         .split(frame.area());
 
-    let header = Paragraph::new(format!("  {} {}  —  Agent Detail", a.emoji, a.name))
-        .style(Style::default().fg(Color::Rgb(80, 200, 255)).bold())
-        .block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(Color::Rgb(60, 60, 80))));
+    // BG
+    let bg_block = Block::default().style(Style::default().bg(app.bg_density.bg()));
+    frame.render_widget(bg_block, frame.area());
+
+    // Header
+    let st_color = match a.status {
+        AgentStatus::Online => t.status_online, AgentStatus::Busy => t.status_busy,
+        AgentStatus::Offline => t.status_offline, _ => t.text_dim,
+    };
+    let header = Paragraph::new(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(format!("{} {}", a.emoji, a.name), Style::default().fg(t.header_title).bold()),
+        Span::raw("  —  "),
+        Span::styled(a.status.to_string(), Style::default().fg(st_color)),
+        Span::raw("    "),
+        Span::styled(match app.focus {
+            Focus::AgentChat => "▌Chat▐",
+            _ => "▌Info▐",
+        }, Style::default().fg(t.accent).bold()),
+    ]))
+    .block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(t.border)).style(Style::default().bg(app.bg_density.bg())));
     frame.render_widget(header, chunks[0]);
+
+    // Body: info left, chat right
+    let body = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(chunks[1]);
+
+    // Info panel
+    let info_active = app.focus != Focus::AgentChat;
+    let ib = if info_active { t.border_active } else { t.border };
 
     let caps = if a.capabilities.is_empty() { "none".into() } else { a.capabilities.join(", ") };
     let rows = vec![
-        ("Host", a.host.clone(), Color::White),
-        ("Location", a.location.clone(), loc_style(&a.location).fg.unwrap_or(Color::White)),
-        ("Status", a.status.to_string(), status_style(&a.status).fg.unwrap_or(Color::White)),
-        ("OS", a.os.clone(), Color::White),
-        ("Kernel", a.kernel.clone(), Color::White),
-        ("Version", a.oc_version.clone(), Color::Rgb(120, 200, 220)),
-        ("SSH User", a.ssh_user.clone(), Color::White),
-        ("Capabilities", caps, Color::White),
-        ("Tokens Today", format!("{}", a.token_burn), Color::White),
-        ("Last Seen", a.last_seen.clone(), Color::White),
-        ("Task", a.current_task.as_deref().unwrap_or("none").to_string(), Color::DarkGray),
+        ("Host", a.host.clone(), t.text),
+        ("Location", a.location.clone(), match a.location.as_str() {
+            "Home" => t.loc_home, "SM" => t.loc_sm, "VPS" => t.loc_vps, "Mobile" => t.loc_mobile, _ => t.text,
+        }),
+        ("Status", a.status.to_string(), st_color),
+        ("OS", a.os.clone(), t.text),
+        ("Kernel", a.kernel.clone(), t.text),
+        ("OC Version", a.oc_version.clone(), t.version),
+        ("SSH User", a.ssh_user.clone(), t.text),
+        ("Capabilities", caps, t.text),
+        ("Tokens Today", format!("{}", a.token_burn), t.text),
+        ("Last Seen", a.last_seen.clone(), t.text),
+        ("Task", a.current_task.as_deref().unwrap_or("none").to_string(), t.text_dim),
     ];
 
     let info: Vec<Line> = rows.iter().map(|(l, v, c)| Line::from(vec![
         Span::raw("  "),
-        Span::styled(format!("{:<16}", l), Style::default().fg(Color::Rgb(180, 180, 200)).bold()),
-        Span::styled(v, Style::default().fg(*c)),
+        Span::styled(format!("{:<14}", l), Style::default().fg(t.text_bold).bold()),
+        Span::styled(v.clone(), Style::default().fg(*c)),
     ])).collect();
 
-    let detail = Paragraph::new(info).block(Block::default().title(" Detail ").borders(Borders::ALL)
-        .border_type(BorderType::Rounded).border_style(Style::default().fg(Color::Rgb(60, 60, 80)))
+    let detail = Paragraph::new(info).block(Block::default()
+        .title(Span::styled(" Info ", Style::default().fg(ib).bold()))
+        .borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(ib))
+        .style(Style::default().bg(app.bg_density.bg()))
         .padding(Padding::new(1, 1, 1, 0)));
-    frame.render_widget(detail, chunks[1]);
+    frame.render_widget(detail, body[0]);
 
-    let footer = Paragraph::new(Line::from(vec![
-        Span::raw("  "),
-        Span::styled("Esc", Style::default().fg(Color::Rgb(80, 200, 255))),
-        Span::styled(" Back  ", Style::default().fg(Color::Rgb(100, 100, 120))),
-        Span::styled("q", Style::default().fg(Color::Rgb(80, 200, 255))),
-        Span::styled(" Quit", Style::default().fg(Color::Rgb(100, 100, 120))),
-    ])).block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).border_style(Style::default().fg(Color::Rgb(40, 40, 60))));
-    frame.render_widget(footer, chunks[2]);
+    // Agent chat
+    render_chat_panel(frame, app, body[1], app.focus == Focus::AgentChat, true);
+
+    // Footer
+    render_footer(frame, app, chunks[2]);
 }
 
-fn render_help(frame: &mut Frame) {
+fn render_help(frame: &mut Frame, app: &App) {
+    let t = &app.theme;
     let sections = vec![
         ("", ""),
         ("NAVIGATION", ""),
-        ("  Tab", "Switch focus between Fleet and Chat"),
+        ("  Tab", "Switch focus (Fleet ↔ Chat / Info ↔ Agent Chat)"),
         ("  ↑↓ / j k", "Navigate fleet list"),
-        ("  Enter", "Open agent detail"),
-        ("  Esc", "Back / unfocus chat"),
-        ("  r", "Refresh all agents via SSH"),
+        ("  Enter", "Open agent detail with dedicated chat"),
+        ("  Esc", "Back to dashboard"),
+        ("  r", "Refresh all agents via SSH (non-blocking)"),
         ("  q", "Quit"),
         ("", ""),
-        ("CHAT", ""),
-        ("  @agent msg", "Message a specific agent"),
-        ("  msg", "Broadcast to all"),
-        ("  PgUp/PgDn", "Scroll chat"),
+        ("THEMES", ""),
+        ("  b", "Cycle background: dark → medium → light → white → terminal"),
+        ("  c", "Cycle colors: standard → noir → paper → 1977 → 2077 → matrix → sunset → arctic"),
         ("", ""),
-        ("CONFIG", ""),
-        ("  fleet.toml", "Fleet agent definitions"),
-        ("  .env", "Database credentials"),
-        ("", "Agents resolve by name, display, or prefix match"),
+        ("CHAT", ""),
+        ("  @agent msg", "Message a specific agent (dashboard)"),
+        ("  Type + Enter", "Send to focused agent (detail screen)"),
+        ("  PgUp/PgDn", "Scroll chat"),
     ];
 
     let lines: Vec<Line> = sections.iter().map(|(l, r)| {
         if r.is_empty() && !l.is_empty() && !l.starts_with(' ') {
-            Line::from(Span::styled(format!("  {}", l), Style::default().fg(Color::Rgb(80, 200, 255)).bold()))
+            Line::from(Span::styled(format!("  {}", l), Style::default().fg(t.accent).bold()))
         } else {
             Line::from(vec![
-                Span::styled(format!("  {:<14}", l), Style::default().fg(Color::Rgb(230, 180, 60))),
-                Span::styled(*r, Style::default().fg(Color::Rgb(180, 180, 200))),
+                Span::styled(format!("  {:<14}", l), Style::default().fg(t.sender_self)),
+                Span::styled(r.to_string(), Style::default().fg(t.text)),
             ])
         }
     }).collect();
 
     let help = Paragraph::new(lines).block(Block::default().title(" Help — press any key to close ")
         .borders(Borders::ALL).border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(Color::Rgb(80, 200, 255)))
+        .border_style(Style::default().fg(t.accent))
+        .style(Style::default().bg(app.bg_density.bg()))
         .padding(Padding::new(2, 2, 1, 1)));
     frame.render_widget(help, frame.area());
+}
+
+fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
+    let t = &app.theme;
+    let footer = Paragraph::new(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(&app.status_message, Style::default().fg(t.text_dim)),
+    ])).block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(t.border))
+        .style(Style::default().bg(app.bg_density.bg())));
+    frame.render_widget(footer, area);
 }
 
 // ---- Main ----
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Load .env from current dir, then ~/.config/sam/
     if dotenvy::dotenv().is_err() {
         if let Ok(home) = std::env::var("HOME") {
             let _ = dotenvy::from_path(std::path::Path::new(&home).join(".config/sam/.env"));
         }
     }
 
-    // Load fleet config
     let fleet_config = match config::load_fleet_config() {
         Ok(c) => c,
-        Err(e) => {
-            eprintln!("Error: {}", e);
-            std::process::exit(1);
-        }
+        Err(e) => { eprintln!("Error: {}", e); std::process::exit(1); }
     };
 
     enable_raw_mode()?;
@@ -527,16 +669,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
 
     let mut app = App::new(fleet_config).await;
-    // Show DB status immediately — no blocking probe on launch
-    let on = app.agents.iter().filter(|a| a.status == AgentStatus::Online).count();
-    app.status_message = format!("v0.7 │ {}/{} from DB │ r=refresh │ Tab=focus │ ?=help", on, app.agents.len());
-    app.last_refresh = Instant::now();
+    app.update_status_bar();
 
     loop {
+        // Drain background probe results (non-blocking)
+        let updates = app.drain_refresh_results();
+        if !updates.is_empty() {
+            // Write to DB in background
+            if let Some(pool) = &app.db_pool {
+                for (idx, _status, _os, _kern, _oc) in &updates {
+                    let a = &app.agents[*idx];
+                    let p = pool.clone();
+                    let (name, st, os, kern, oc) = (
+                        a.db_name.clone(), a.status.to_db_str().to_string(),
+                        if a.os.is_empty() { None } else { Some(a.os.clone()) },
+                        if a.kernel.is_empty() { None } else { Some(a.kernel.clone()) },
+                        if a.oc_version.is_empty() { None } else { Some(a.oc_version.clone()) },
+                    );
+                    tokio::spawn(async move {
+                        let _ = db::update_agent_status(&p, &name, &st,
+                            os.as_deref(), kern.as_deref(), oc.as_deref()).await;
+                    });
+                }
+            }
+            app.update_status_bar();
+        }
+
         terminal.draw(|f| match app.screen {
             Screen::Dashboard => render_dashboard(f, &app),
             Screen::AgentDetail => render_detail(f, &app),
-            Screen::Help => render_help(f),
+            Screen::Help => render_help(f, &app),
         })?;
 
         if event::poll(Duration::from_millis(100))? {
@@ -544,10 +706,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 if key.kind == KeyEventKind::Press {
                     match app.screen {
                         Screen::Help => { app.screen = Screen::Dashboard; }
-                        Screen::AgentDetail => match key.code {
-                            KeyCode::Esc => app.screen = Screen::Dashboard,
-                            KeyCode::Char('q') => app.should_quit = true,
-                            _ => {}
+                        Screen::AgentDetail => match app.focus {
+                            Focus::AgentChat => match key.code {
+                                KeyCode::Esc => app.focus = Focus::Fleet,
+                                KeyCode::Tab => app.focus = Focus::Fleet,
+                                KeyCode::Enter => app.send_agent_message().await,
+                                KeyCode::Backspace => { app.agent_chat_input.pop(); }
+                                KeyCode::Char(c) => app.agent_chat_input.push(c),
+                                KeyCode::PageUp => app.agent_chat_scroll = app.agent_chat_scroll.saturating_add(5),
+                                KeyCode::PageDown => app.agent_chat_scroll = app.agent_chat_scroll.saturating_sub(5),
+                                _ => {}
+                            },
+                            _ => match key.code {
+                                KeyCode::Esc => { app.screen = Screen::Dashboard; app.focus = Focus::Fleet; }
+                                KeyCode::Tab => app.focus = Focus::AgentChat,
+                                KeyCode::Char('q') => app.should_quit = true,
+                                KeyCode::Char('r') => app.start_refresh(),
+                                KeyCode::Char('b') => app.cycle_bg(),
+                                KeyCode::Char('c') => app.cycle_theme(),
+                                _ => {}
+                            },
                         },
                         Screen::Dashboard => match app.focus {
                             Focus::Fleet => match key.code {
@@ -555,17 +733,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 KeyCode::Tab => app.focus = Focus::Chat,
                                 KeyCode::Up | KeyCode::Char('k') => app.previous(),
                                 KeyCode::Down | KeyCode::Char('j') => app.next(),
-                                KeyCode::Enter => app.screen = Screen::AgentDetail,
-                                KeyCode::Char('?') => app.screen = Screen::Help,
-                                KeyCode::Char('r') => {
-                                    app.status_message = "Refreshing...".into();
-                                    terminal.draw(|f| render_dashboard(f, &app))?;
-                                    let sip = app.self_ip.clone();
-                                    refresh_fleet(&mut app.agents, &app.db_pool, &sip).await;
-                                    app.last_refresh = Instant::now();
-                                    let on = app.agents.iter().filter(|a| a.status == AgentStatus::Online).count();
-                                    app.status_message = format!("v0.7 │ {}/{} online │ Tab=focus ?=help", on, app.agents.len());
+                                KeyCode::Enter => {
+                                    app.screen = Screen::AgentDetail;
+                                    app.focus = Focus::Fleet;
+                                    app.agent_chat_input.clear();
+                                    app.agent_chat_scroll = 0;
                                 }
+                                KeyCode::Char('?') => app.screen = Screen::Help,
+                                KeyCode::Char('r') => app.start_refresh(),
+                                KeyCode::Char('b') => app.cycle_bg(),
+                                KeyCode::Char('c') => app.cycle_theme(),
                                 _ => {}
                             },
                             Focus::Chat => match key.code {
@@ -577,20 +754,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 KeyCode::PageDown => app.chat_scroll = app.chat_scroll.saturating_sub(5),
                                 _ => {}
                             },
+                            _ => {}
                         },
                     }
                 }
             }
         }
 
-        if app.last_refresh.elapsed() > Duration::from_secs(30) {
-            let sip = app.self_ip.clone();
-            refresh_fleet(&mut app.agents, &app.db_pool, &sip).await;
-            app.last_refresh = Instant::now();
-            let on = app.agents.iter().filter(|a| a.status == AgentStatus::Online).count();
-            app.status_message = format!("v0.7 │ {}/{} online │ Tab=focus ?=help", on, app.agents.len());
+        // Auto-refresh every 30s (non-blocking)
+        if app.last_refresh.elapsed() > Duration::from_secs(30) && !app.refreshing {
+            app.start_refresh();
         }
 
+        // Poll chat every 3s — spawn so it doesn't block
         if app.last_chat_poll.elapsed() > Duration::from_secs(3) {
             app.poll_chat().await;
             app.last_chat_poll = Instant::now();

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,496 @@
+use ratatui::prelude::*;
+
+// ---- Background Density ----
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum BgDensity {
+    Dark,       // Default — near black
+    Medium,     // Slightly lighter
+    Light,      // Visible grey
+    White,      // Light mode
+    Transparent, // Pure terminal default
+}
+
+impl BgDensity {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Dark => Self::Medium,
+            Self::Medium => Self::Light,
+            Self::Light => Self::White,
+            Self::White => Self::Transparent,
+            Self::Transparent => Self::Dark,
+        }
+    }
+
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Dark => "dark",
+            Self::Medium => "medium",
+            Self::Light => "light",
+            Self::White => "white",
+            Self::Transparent => "terminal",
+        }
+    }
+
+    pub fn bg(&self) -> Color {
+        match self {
+            Self::Dark => Color::Rgb(10, 10, 18),
+            Self::Medium => Color::Rgb(30, 30, 40),
+            Self::Light => Color::Rgb(60, 60, 70),
+            Self::White => Color::Rgb(230, 230, 235),
+            Self::Transparent => Color::Reset,
+        }
+    }
+
+    pub fn is_light(&self) -> bool {
+        matches!(self, Self::White)
+    }
+}
+
+// ---- Color Themes ----
+
+#[derive(Clone, Copy, PartialEq)]
+pub enum ThemeName {
+    Standard,   // Original cyan/blue
+    Noir,       // All white/grey on black
+    Paper,      // All black on white
+    Retro1977,  // Warm amber/orange/brown
+    Cyber2077,  // Neon pink/cyan/yellow
+    Matrix,     // Green on black
+    Sunset,     // Warm orange/red/purple
+    Arctic,     // Cool blue/white/silver
+}
+
+impl ThemeName {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Standard => Self::Noir,
+            Self::Noir => Self::Paper,
+            Self::Paper => Self::Retro1977,
+            Self::Retro1977 => Self::Cyber2077,
+            Self::Cyber2077 => Self::Matrix,
+            Self::Matrix => Self::Sunset,
+            Self::Sunset => Self::Arctic,
+            Self::Arctic => Self::Standard,
+        }
+    }
+
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Standard => "standard",
+            Self::Noir => "noir",
+            Self::Paper => "paper",
+            Self::Retro1977 => "1977",
+            Self::Cyber2077 => "2077",
+            Self::Matrix => "matrix",
+            Self::Sunset => "sunset",
+            Self::Arctic => "arctic",
+        }
+    }
+}
+
+// The actual resolved colors for rendering
+#[derive(Clone, Copy)]
+pub struct Theme {
+    pub accent: Color,         // Primary accent (borders, highlights)
+    pub accent2: Color,        // Secondary accent
+    pub text: Color,           // Main text
+    pub text_dim: Color,       // Dimmed text (timestamps, labels)
+    pub text_bold: Color,      // Bold/emphasized text
+    pub border: Color,         // Inactive borders
+    pub border_active: Color,  // Active borders
+    pub selected_bg: Color,    // Selected row background
+    pub sender_self: Color,    // Chat: own messages
+    pub sender_other: Color,   // Chat: other messages
+    pub response: Color,       // Chat: response text
+    pub status_online: Color,
+    pub status_busy: Color,
+    pub status_offline: Color,
+    pub loc_home: Color,
+    pub loc_sm: Color,
+    pub loc_vps: Color,
+    pub loc_mobile: Color,
+    pub version: Color,
+    pub pending: Color,        // Awaiting response
+    pub header_title: Color,
+}
+
+impl Theme {
+    pub fn resolve(name: ThemeName, bg: BgDensity) -> Self {
+        let light = bg.is_light();
+        match name {
+            ThemeName::Standard => if light { Self::standard_light() } else { Self::standard() },
+            ThemeName::Noir => if light { Self::paper() } else { Self::noir() },
+            ThemeName::Paper => Self::paper(),
+            ThemeName::Retro1977 => Self::retro1977(light),
+            ThemeName::Cyber2077 => Self::cyber2077(light),
+            ThemeName::Matrix => Self::matrix(light),
+            ThemeName::Sunset => Self::sunset(light),
+            ThemeName::Arctic => Self::arctic(light),
+        }
+    }
+
+    fn standard() -> Self {
+        Self {
+            accent: Color::Rgb(80, 200, 255),
+            accent2: Color::Rgb(120, 200, 220),
+            text: Color::Rgb(220, 220, 230),
+            text_dim: Color::Rgb(80, 80, 100),
+            text_bold: Color::White,
+            border: Color::Rgb(50, 50, 70),
+            border_active: Color::Rgb(80, 200, 255),
+            selected_bg: Color::Rgb(35, 40, 60),
+            sender_self: Color::Rgb(230, 180, 60),
+            sender_other: Color::Rgb(100, 220, 100),
+            response: Color::Rgb(160, 210, 170),
+            status_online: Color::Green,
+            status_busy: Color::Yellow,
+            status_offline: Color::Red,
+            loc_home: Color::Rgb(100, 200, 100),
+            loc_sm: Color::Rgb(230, 180, 60),
+            loc_vps: Color::Rgb(180, 120, 220),
+            loc_mobile: Color::Rgb(80, 180, 230),
+            version: Color::Rgb(120, 200, 220),
+            pending: Color::Rgb(100, 100, 120),
+            header_title: Color::Rgb(80, 200, 255),
+        }
+    }
+
+    fn standard_light() -> Self {
+        Self {
+            accent: Color::Rgb(0, 120, 180),
+            accent2: Color::Rgb(0, 100, 160),
+            text: Color::Rgb(30, 30, 40),
+            text_dim: Color::Rgb(100, 100, 120),
+            text_bold: Color::Black,
+            border: Color::Rgb(180, 180, 190),
+            border_active: Color::Rgb(0, 120, 180),
+            selected_bg: Color::Rgb(210, 225, 240),
+            sender_self: Color::Rgb(180, 120, 0),
+            sender_other: Color::Rgb(0, 140, 60),
+            response: Color::Rgb(0, 120, 80),
+            status_online: Color::Rgb(0, 150, 0),
+            status_busy: Color::Rgb(200, 150, 0),
+            status_offline: Color::Rgb(200, 0, 0),
+            loc_home: Color::Rgb(0, 140, 60),
+            loc_sm: Color::Rgb(180, 120, 0),
+            loc_vps: Color::Rgb(120, 60, 180),
+            loc_mobile: Color::Rgb(0, 120, 180),
+            version: Color::Rgb(0, 100, 160),
+            pending: Color::Rgb(140, 140, 160),
+            header_title: Color::Rgb(0, 120, 180),
+        }
+    }
+
+    fn noir() -> Self {
+        Self {
+            accent: Color::White,
+            accent2: Color::Rgb(180, 180, 180),
+            text: Color::Rgb(200, 200, 200),
+            text_dim: Color::Rgb(80, 80, 80),
+            text_bold: Color::White,
+            border: Color::Rgb(40, 40, 40),
+            border_active: Color::White,
+            selected_bg: Color::Rgb(30, 30, 30),
+            sender_self: Color::White,
+            sender_other: Color::Rgb(160, 160, 160),
+            response: Color::Rgb(140, 140, 140),
+            status_online: Color::White,
+            status_busy: Color::Rgb(160, 160, 160),
+            status_offline: Color::Rgb(60, 60, 60),
+            loc_home: Color::Rgb(180, 180, 180),
+            loc_sm: Color::Rgb(160, 160, 160),
+            loc_vps: Color::Rgb(140, 140, 140),
+            loc_mobile: Color::Rgb(120, 120, 120),
+            version: Color::Rgb(180, 180, 180),
+            pending: Color::Rgb(80, 80, 80),
+            header_title: Color::White,
+        }
+    }
+
+    fn paper() -> Self {
+        Self {
+            accent: Color::Black,
+            accent2: Color::Rgb(60, 60, 60),
+            text: Color::Rgb(30, 30, 30),
+            text_dim: Color::Rgb(120, 120, 120),
+            text_bold: Color::Black,
+            border: Color::Rgb(180, 180, 180),
+            border_active: Color::Black,
+            selected_bg: Color::Rgb(220, 220, 225),
+            sender_self: Color::Black,
+            sender_other: Color::Rgb(60, 60, 60),
+            response: Color::Rgb(80, 80, 80),
+            status_online: Color::Rgb(0, 100, 0),
+            status_busy: Color::Rgb(150, 100, 0),
+            status_offline: Color::Rgb(160, 0, 0),
+            loc_home: Color::Rgb(0, 100, 0),
+            loc_sm: Color::Rgb(150, 100, 0),
+            loc_vps: Color::Rgb(100, 50, 150),
+            loc_mobile: Color::Rgb(0, 80, 160),
+            version: Color::Rgb(60, 60, 60),
+            pending: Color::Rgb(140, 140, 140),
+            header_title: Color::Black,
+        }
+    }
+
+    fn retro1977(light: bool) -> Self {
+        if light {
+            Self {
+                accent: Color::Rgb(160, 80, 0),
+                accent2: Color::Rgb(140, 70, 0),
+                text: Color::Rgb(60, 40, 20),
+                text_dim: Color::Rgb(140, 120, 90),
+                text_bold: Color::Rgb(100, 50, 0),
+                border: Color::Rgb(190, 170, 140),
+                border_active: Color::Rgb(160, 80, 0),
+                selected_bg: Color::Rgb(230, 210, 180),
+                sender_self: Color::Rgb(160, 80, 0),
+                sender_other: Color::Rgb(120, 80, 20),
+                response: Color::Rgb(100, 70, 30),
+                status_online: Color::Rgb(80, 120, 0),
+                status_busy: Color::Rgb(180, 120, 0),
+                status_offline: Color::Rgb(160, 40, 0),
+                loc_home: Color::Rgb(80, 120, 0),
+                loc_sm: Color::Rgb(180, 120, 0),
+                loc_vps: Color::Rgb(140, 60, 100),
+                loc_mobile: Color::Rgb(0, 100, 140),
+                version: Color::Rgb(140, 70, 0),
+                pending: Color::Rgb(160, 140, 110),
+                header_title: Color::Rgb(160, 80, 0),
+            }
+        } else {
+            Self {
+                accent: Color::Rgb(255, 170, 50),
+                accent2: Color::Rgb(220, 140, 40),
+                text: Color::Rgb(230, 200, 160),
+                text_dim: Color::Rgb(120, 90, 50),
+                text_bold: Color::Rgb(255, 200, 100),
+                border: Color::Rgb(80, 60, 30),
+                border_active: Color::Rgb(255, 170, 50),
+                selected_bg: Color::Rgb(50, 35, 15),
+                sender_self: Color::Rgb(255, 170, 50),
+                sender_other: Color::Rgb(200, 160, 80),
+                response: Color::Rgb(180, 150, 100),
+                status_online: Color::Rgb(180, 220, 80),
+                status_busy: Color::Rgb(255, 180, 40),
+                status_offline: Color::Rgb(200, 60, 30),
+                loc_home: Color::Rgb(180, 220, 80),
+                loc_sm: Color::Rgb(255, 180, 40),
+                loc_vps: Color::Rgb(200, 120, 160),
+                loc_mobile: Color::Rgb(100, 180, 220),
+                version: Color::Rgb(220, 140, 40),
+                pending: Color::Rgb(120, 90, 50),
+                header_title: Color::Rgb(255, 170, 50),
+            }
+        }
+    }
+
+    fn cyber2077(light: bool) -> Self {
+        if light {
+            Self {
+                accent: Color::Rgb(200, 0, 120),
+                accent2: Color::Rgb(0, 160, 200),
+                text: Color::Rgb(30, 20, 40),
+                text_dim: Color::Rgb(120, 100, 140),
+                text_bold: Color::Rgb(180, 0, 100),
+                border: Color::Rgb(180, 170, 190),
+                border_active: Color::Rgb(200, 0, 120),
+                selected_bg: Color::Rgb(240, 220, 240),
+                sender_self: Color::Rgb(200, 0, 120),
+                sender_other: Color::Rgb(0, 140, 180),
+                response: Color::Rgb(0, 120, 160),
+                status_online: Color::Rgb(0, 200, 100),
+                status_busy: Color::Rgb(220, 180, 0),
+                status_offline: Color::Rgb(200, 0, 60),
+                loc_home: Color::Rgb(0, 160, 80),
+                loc_sm: Color::Rgb(200, 150, 0),
+                loc_vps: Color::Rgb(160, 0, 200),
+                loc_mobile: Color::Rgb(0, 140, 200),
+                version: Color::Rgb(0, 160, 200),
+                pending: Color::Rgb(140, 120, 160),
+                header_title: Color::Rgb(200, 0, 120),
+            }
+        } else {
+            Self {
+                accent: Color::Rgb(255, 0, 150),
+                accent2: Color::Rgb(0, 255, 255),
+                text: Color::Rgb(230, 220, 240),
+                text_dim: Color::Rgb(100, 80, 120),
+                text_bold: Color::Rgb(255, 255, 100),
+                border: Color::Rgb(60, 30, 80),
+                border_active: Color::Rgb(255, 0, 150),
+                selected_bg: Color::Rgb(40, 15, 50),
+                sender_self: Color::Rgb(255, 255, 100),
+                sender_other: Color::Rgb(0, 255, 255),
+                response: Color::Rgb(0, 200, 200),
+                status_online: Color::Rgb(0, 255, 100),
+                status_busy: Color::Rgb(255, 255, 0),
+                status_offline: Color::Rgb(255, 0, 60),
+                loc_home: Color::Rgb(0, 255, 100),
+                loc_sm: Color::Rgb(255, 200, 0),
+                loc_vps: Color::Rgb(200, 0, 255),
+                loc_mobile: Color::Rgb(0, 200, 255),
+                version: Color::Rgb(0, 255, 255),
+                pending: Color::Rgb(100, 80, 120),
+                header_title: Color::Rgb(255, 0, 150),
+            }
+        }
+    }
+
+    fn matrix(light: bool) -> Self {
+        if light {
+            Self {
+                accent: Color::Rgb(0, 120, 0),
+                accent2: Color::Rgb(0, 100, 0),
+                text: Color::Rgb(0, 60, 0),
+                text_dim: Color::Rgb(80, 140, 80),
+                text_bold: Color::Rgb(0, 100, 0),
+                border: Color::Rgb(140, 180, 140),
+                border_active: Color::Rgb(0, 120, 0),
+                selected_bg: Color::Rgb(210, 235, 210),
+                sender_self: Color::Rgb(0, 120, 0),
+                sender_other: Color::Rgb(0, 80, 0),
+                response: Color::Rgb(0, 100, 0),
+                status_online: Color::Rgb(0, 140, 0),
+                status_busy: Color::Rgb(100, 140, 0),
+                status_offline: Color::Rgb(140, 0, 0),
+                loc_home: Color::Rgb(0, 120, 0),
+                loc_sm: Color::Rgb(0, 100, 0),
+                loc_vps: Color::Rgb(0, 80, 0),
+                loc_mobile: Color::Rgb(0, 60, 0),
+                version: Color::Rgb(0, 100, 0),
+                pending: Color::Rgb(80, 140, 80),
+                header_title: Color::Rgb(0, 120, 0),
+            }
+        } else {
+            Self {
+                accent: Color::Rgb(0, 255, 0),
+                accent2: Color::Rgb(0, 200, 0),
+                text: Color::Rgb(0, 220, 0),
+                text_dim: Color::Rgb(0, 80, 0),
+                text_bold: Color::Rgb(0, 255, 0),
+                border: Color::Rgb(0, 50, 0),
+                border_active: Color::Rgb(0, 255, 0),
+                selected_bg: Color::Rgb(0, 25, 0),
+                sender_self: Color::Rgb(0, 255, 0),
+                sender_other: Color::Rgb(0, 180, 0),
+                response: Color::Rgb(0, 160, 0),
+                status_online: Color::Rgb(0, 255, 0),
+                status_busy: Color::Rgb(0, 200, 0),
+                status_offline: Color::Rgb(0, 60, 0),
+                loc_home: Color::Rgb(0, 220, 0),
+                loc_sm: Color::Rgb(0, 200, 0),
+                loc_vps: Color::Rgb(0, 180, 0),
+                loc_mobile: Color::Rgb(0, 160, 0),
+                version: Color::Rgb(0, 200, 0),
+                pending: Color::Rgb(0, 80, 0),
+                header_title: Color::Rgb(0, 255, 0),
+            }
+        }
+    }
+
+    fn sunset(light: bool) -> Self {
+        if light {
+            Self {
+                accent: Color::Rgb(200, 60, 40),
+                accent2: Color::Rgb(180, 80, 120),
+                text: Color::Rgb(60, 30, 30),
+                text_dim: Color::Rgb(160, 120, 110),
+                text_bold: Color::Rgb(180, 40, 20),
+                border: Color::Rgb(200, 180, 170),
+                border_active: Color::Rgb(200, 60, 40),
+                selected_bg: Color::Rgb(240, 220, 210),
+                sender_self: Color::Rgb(200, 60, 40),
+                sender_other: Color::Rgb(160, 80, 120),
+                response: Color::Rgb(140, 70, 100),
+                status_online: Color::Rgb(80, 160, 0),
+                status_busy: Color::Rgb(220, 140, 0),
+                status_offline: Color::Rgb(180, 0, 0),
+                loc_home: Color::Rgb(80, 140, 0),
+                loc_sm: Color::Rgb(200, 120, 0),
+                loc_vps: Color::Rgb(160, 40, 120),
+                loc_mobile: Color::Rgb(0, 100, 180),
+                version: Color::Rgb(180, 80, 120),
+                pending: Color::Rgb(160, 130, 120),
+                header_title: Color::Rgb(200, 60, 40),
+            }
+        } else {
+            Self {
+                accent: Color::Rgb(255, 100, 50),
+                accent2: Color::Rgb(255, 80, 160),
+                text: Color::Rgb(240, 210, 200),
+                text_dim: Color::Rgb(120, 80, 60),
+                text_bold: Color::Rgb(255, 200, 100),
+                border: Color::Rgb(80, 40, 30),
+                border_active: Color::Rgb(255, 100, 50),
+                selected_bg: Color::Rgb(50, 25, 15),
+                sender_self: Color::Rgb(255, 200, 100),
+                sender_other: Color::Rgb(255, 120, 180),
+                response: Color::Rgb(220, 100, 150),
+                status_online: Color::Rgb(255, 200, 80),
+                status_busy: Color::Rgb(255, 140, 40),
+                status_offline: Color::Rgb(140, 40, 30),
+                loc_home: Color::Rgb(255, 180, 80),
+                loc_sm: Color::Rgb(255, 140, 40),
+                loc_vps: Color::Rgb(200, 80, 180),
+                loc_mobile: Color::Rgb(100, 160, 240),
+                version: Color::Rgb(255, 80, 160),
+                pending: Color::Rgb(120, 80, 60),
+                header_title: Color::Rgb(255, 100, 50),
+            }
+        }
+    }
+
+    fn arctic(light: bool) -> Self {
+        if light {
+            Self {
+                accent: Color::Rgb(0, 80, 160),
+                accent2: Color::Rgb(60, 120, 180),
+                text: Color::Rgb(20, 30, 50),
+                text_dim: Color::Rgb(100, 120, 150),
+                text_bold: Color::Rgb(0, 60, 140),
+                border: Color::Rgb(170, 185, 200),
+                border_active: Color::Rgb(0, 80, 160),
+                selected_bg: Color::Rgb(210, 225, 245),
+                sender_self: Color::Rgb(0, 80, 160),
+                sender_other: Color::Rgb(60, 120, 180),
+                response: Color::Rgb(40, 100, 160),
+                status_online: Color::Rgb(0, 140, 100),
+                status_busy: Color::Rgb(160, 140, 0),
+                status_offline: Color::Rgb(160, 40, 40),
+                loc_home: Color::Rgb(0, 120, 80),
+                loc_sm: Color::Rgb(140, 120, 0),
+                loc_vps: Color::Rgb(100, 60, 160),
+                loc_mobile: Color::Rgb(0, 100, 180),
+                version: Color::Rgb(60, 120, 180),
+                pending: Color::Rgb(120, 140, 160),
+                header_title: Color::Rgb(0, 80, 160),
+            }
+        } else {
+            Self {
+                accent: Color::Rgb(120, 180, 255),
+                accent2: Color::Rgb(180, 210, 255),
+                text: Color::Rgb(210, 225, 245),
+                text_dim: Color::Rgb(80, 100, 130),
+                text_bold: Color::White,
+                border: Color::Rgb(40, 50, 70),
+                border_active: Color::Rgb(120, 180, 255),
+                selected_bg: Color::Rgb(25, 35, 55),
+                sender_self: Color::Rgb(180, 210, 255),
+                sender_other: Color::Rgb(120, 180, 255),
+                response: Color::Rgb(140, 190, 240),
+                status_online: Color::Rgb(100, 220, 180),
+                status_busy: Color::Rgb(220, 200, 100),
+                status_offline: Color::Rgb(180, 80, 80),
+                loc_home: Color::Rgb(100, 200, 160),
+                loc_sm: Color::Rgb(200, 180, 100),
+                loc_vps: Color::Rgb(160, 120, 220),
+                loc_mobile: Color::Rgb(100, 180, 240),
+                version: Color::Rgb(180, 210, 255),
+                pending: Color::Rgb(80, 100, 130),
+                header_title: Color::Rgb(120, 180, 255),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Changes

### 🎨 Theme System
- **`b`** cycles background density: dark → medium → light → white → terminal
- **`c`** cycles 8 color schemes: standard, noir, paper, 1977, 2077, matrix, sunset, arctic
- All themes auto-adapt to light/dark backgrounds

### 💬 Agent Detail Chat
- Enter on fleet agent opens split: info (40%) + dedicated chat (60%)
- Tab switches between info panel and agent chat
- Messages auto-target focused agent (no @prefix needed)

### ⚡ Non-Blocking Refresh
- SSH probes run via `tokio::spawn` + mpsc channel — TUI never blocks
- DB writes fire-and-forget in background
- Agents update individually as probes complete
- Status bar shows ⟳ while refreshing

### 🔧 New module
- `src/theme.rs` — full theme engine with 8 schemes × 5 bg densities