### PR TITLE
feat: Security hardening + panic recovery + SSH timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,49 @@ jobs:
 
       - name: Test
         run: cargo test
+
+  security-audit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit
+
+      - name: Security audit
+        run: cargo audit
+
+  secret-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan for hardcoded secrets
+        run: |
+          echo "Scanning for potential secrets..."
+          FOUND=0
+
+          # Check for IP patterns that look like private infra
+          if grep -rn '[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}' src/ --include="*.rs" | grep -v '127.0.0.1\|0.0.0.0\|localhost\|test\|example\|0\.0\.0\.0' | grep -v '//.*[0-9]'; then
+            echo "⚠️  Found hardcoded IPs in source"
+            FOUND=1
+          fi
+
+          # Check for password patterns
+          if grep -rni 'password\s*=\s*"[^"]\+"\|passwd\|secret.*=.*"' src/ --include="*.rs" | grep -v 'sanitize\|mask\|test\|example\|placeholder'; then
+            echo "⚠️  Found potential hardcoded passwords"
+            FOUND=1
+          fi
+
+          if [ $FOUND -eq 0 ]; then
+            echo "✅ No secrets detected"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,34 @@
+# Build
 /target
+*.swp
+*.swo
+*~
+
+# Secrets & config
 .env
+*.env
+config.toml
 fleet.toml
+
+# Keys & certs
+*.pem
+*.key
+*.p12
+*.pfx
+id_rsa*
+*.pub
+
+# OS
+.DS_Store
+Thumbs.db
+*.log
+
+# IDE
+.idea/
+.vscode/
+*.code-workspace
+
+# Dev artifacts
 docs/mock-screenshot.py
+/tmp/
+*.bak

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1529,6 +1529,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1576,6 +1582,7 @@ dependencies = [
  "dotenvy",
  "mysql_async",
  "ratatui",
+ "regex-lite",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ crossterm = "0.29.0"
 dotenvy = "0.15.7"
 mysql_async = "0.36.1"
 ratatui = "0.30.0"
+regex-lite = "0.1.9"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["full"] }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,4 +1,14 @@
 use mysql_async::prelude::*;
+
+/// Sanitize error messages to remove passwords/credentials
+pub fn sanitize_error(msg: &str) -> String {
+    // Mask password in mysql:// URLs
+    let re_url = regex_lite::Regex::new(r"mysql://[^:]+:([^@]+)@").unwrap();
+    let sanitized = re_url.replace_all(msg, "mysql://***:***@").to_string();
+    // Mask any password= patterns
+    let re_pass = regex_lite::Regex::new(r"(?i)(password|pass|pwd)\s*=\s*\S+").unwrap();
+    re_pass.replace_all(&sanitized, "$1=***").to_string()
+}
 use mysql_async::Pool;
 use std::env;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,7 +323,14 @@ async fn probe_agent(host: &str, user: &str, self_ip: &str) -> (AgentStatus, Str
     }
     let tgt = format!("{}@{}", user, host);
     let script = r#"OS=$(. /etc/os-release 2>/dev/null && echo "$NAME $VERSION_ID" || (sw_vers -productName 2>/dev/null; sw_vers -productVersion 2>/dev/null) || echo ?); KERN=$(uname -r); OC=$(openclaw --version 2>/dev/null || echo ?); echo "OS:$OS"; echo "KERN:$KERN"; echo "OC:$OC""#;
-    let result = Command::new("ssh").args(["-o","ConnectTimeout=4","-o","StrictHostKeyChecking=no","-o","BatchMode=yes",&tgt,"bash","-c",script]).output().await;
+    let result = tokio::time::timeout(
+        Duration::from_secs(8),
+        Command::new("ssh").args(["-o","ConnectTimeout=4","-o","StrictHostKeyChecking=no","-o","BatchMode=yes",&tgt,"bash","-c",script]).output()
+    ).await;
+    let result = match result {
+        Ok(r) => r,
+        Err(_) => return (AgentStatus::Offline, String::new(), String::new(), String::new()),
+    };
     match result {
         Ok(o) if o.status.success() => {
             let s = String::from_utf8_lossy(&o.stdout);
@@ -699,6 +706,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Ok(c) => c,
         Err(e) => { eprintln!("Error: {}", e); std::process::exit(1); }
     };
+
+    // Install panic hook that restores terminal before printing panic
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = stdout().execute(crossterm::event::DisableMouseCapture);
+        let _ = stdout().execute(LeaveAlternateScreen);
+        // Write crash log
+        if let Ok(mut f) = std::fs::OpenOptions::new().create(true).append(true)
+            .open("/tmp/sam-crash.log") {
+            use std::io::Write;
+            let _ = writeln!(f, "[{}] PANIC: {}", now_str(), info);
+        }
+        original_hook(info);
+    }));
 
     enable_raw_mode()?;
     stdout().execute(EnterAlternateScreen)?;


### PR DESCRIPTION
Closes #18, closes #7

## Security
- Comprehensive `.gitignore` (keys, certs, configs, IDE files)
- `db::sanitize_error()` masks passwords in mysql:// URLs and error messages
- CI: `cargo audit` for dependency vulnerabilities
- CI: secret scanner catches hardcoded IPs/passwords in source

## Panic Recovery
- Custom panic hook restores terminal state before printing the panic
- Disables raw mode, mouse capture, and alternate screen on crash
- Crash details written to `/tmp/sam-crash.log`
- **No more stuck terminals** when the TUI panics

## SSH Resilience
- 8-second `tokio::time::timeout` wrapping all SSH probe commands
- Prevents hung SSH connections from blocking indefinitely