### PR TITLE
feat: CLI arguments, config file, setup wizard, theme persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +199,52 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -370,6 +466,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +670,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -763,6 +891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +964,16 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+]
 
 [[package]]
 name = "libz-sys"
@@ -1116,6 +1260,18 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -1506,6 +1662,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1578,7 +1745,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 name = "sam-mission-control"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "crossterm",
+ "dirs",
  "dotenvy",
  "mysql_async",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+clap = { version = "4.5.60", features = ["derive"] }
 crossterm = "0.29.0"
+dirs = "6.0.0"
 dotenvy = "0.15.7"
 mysql_async = "0.36.1"
 ratatui = "0.30.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,350 @@
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Parser)]
+#[command(name = "sam", version, about = "S.A.M Mission Control — Fleet orchestration TUI")]
+pub struct Cli {
+    /// Path to config file
+    #[arg(short, long, global = true)]
+    pub config: Option<PathBuf>,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Print fleet status and exit
+    Status,
+    /// Send a message to an agent
+    Chat {
+        /// Agent name
+        agent: String,
+        /// Message to send
+        message: Vec<String>,
+    },
+    /// Run interactive setup wizard
+    Setup,
+    /// Print version info
+    Version,
+}
+
+/// Persistent config file (~/.config/sam/config.toml)
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SamConfig {
+    #[serde(default)]
+    pub database: DatabaseConfig,
+    #[serde(default)]
+    pub tui: TuiConfig,
+    #[serde(default)]
+    pub fleet: FleetConfig,
+    #[serde(default)]
+    pub identity: IdentityConfig,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct DatabaseConfig {
+    pub url: Option<String>,
+    pub host: Option<String>,
+    pub port: Option<u16>,
+    pub user: Option<String>,
+    pub password: Option<String>,
+    pub database: Option<String>,
+}
+
+impl Default for DatabaseConfig {
+    fn default() -> Self {
+        Self { url: None, host: None, port: None, user: None, password: None, database: None }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct TuiConfig {
+    #[serde(default = "default_theme")]
+    pub theme: String,
+    #[serde(default = "default_bg")]
+    pub background: String,
+    #[serde(default = "default_refresh")]
+    pub refresh_interval: u64,
+    #[serde(default = "default_chat_poll")]
+    pub chat_poll_interval: u64,
+}
+
+impl Default for TuiConfig {
+    fn default() -> Self {
+        Self { theme: default_theme(), background: default_bg(), refresh_interval: default_refresh(), chat_poll_interval: default_chat_poll() }
+    }
+}
+
+fn default_theme() -> String { "standard".into() }
+fn default_bg() -> String { "dark".into() }
+fn default_refresh() -> u64 { 30 }
+fn default_chat_poll() -> u64 { 3 }
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct FleetConfig {
+    pub config_path: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IdentityConfig {
+    #[serde(default = "default_user")]
+    pub user: String,
+}
+
+impl Default for IdentityConfig {
+    fn default() -> Self { Self { user: default_user() } }
+}
+
+fn default_user() -> String { "operator".into() }
+
+impl SamConfig {
+    /// Load config from file, or return defaults
+    pub fn load(path: Option<&PathBuf>) -> Self {
+        // Explicit path
+        if let Some(p) = path {
+            if let Ok(content) = std::fs::read_to_string(p) {
+                if let Ok(cfg) = toml::from_str(&content) {
+                    return cfg;
+                }
+            }
+        }
+
+        // Default paths
+        let candidates = vec![
+            PathBuf::from("config.toml"),
+            dirs::config_dir().unwrap_or_default().join("sam/config.toml"),
+        ];
+
+        for p in candidates {
+            if let Ok(content) = std::fs::read_to_string(&p) {
+                if let Ok(cfg) = toml::from_str(&content) {
+                    return cfg;
+                }
+            }
+        }
+
+        Self::default()
+    }
+
+    /// Save config to default location
+    pub fn save(&self) -> Result<(), String> {
+        let dir = dirs::config_dir().unwrap_or_default().join("sam");
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        let path = dir.join("config.toml");
+        let content = toml::to_string_pretty(self).map_err(|e| e.to_string())?;
+        std::fs::write(&path, &content).map_err(|e| e.to_string())?;
+
+        // Set file permissions to 0600 on Unix
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+        }
+
+        Ok(())
+    }
+
+    /// Apply config to env vars (for backward compat with .env loading)
+    pub fn apply_to_env(&self) {
+        unsafe {
+            if let Some(url) = &self.database.url {
+                if std::env::var("SAM_DB_URL").is_err() {
+                    std::env::set_var("SAM_DB_URL", url);
+                }
+            }
+            if let Some(h) = &self.database.host {
+                if std::env::var("SAM_DB_HOST").is_err() { std::env::set_var("SAM_DB_HOST", h); }
+            }
+            if let Some(p) = &self.database.port {
+                if std::env::var("SAM_DB_PORT").is_err() { std::env::set_var("SAM_DB_PORT", p.to_string()); }
+            }
+            if let Some(u) = &self.database.user {
+                if std::env::var("SAM_DB_USER").is_err() { std::env::set_var("SAM_DB_USER", u); }
+            }
+            if let Some(p) = &self.database.password {
+                if std::env::var("SAM_DB_PASS").is_err() { std::env::set_var("SAM_DB_PASS", p); }
+            }
+            if let Some(d) = &self.database.database {
+                if std::env::var("SAM_DB_NAME").is_err() { std::env::set_var("SAM_DB_NAME", d); }
+            }
+            if std::env::var("SAM_USER").is_err() {
+                std::env::set_var("SAM_USER", &self.identity.user);
+            }
+        }
+    }
+
+    /// Resolve theme name to ThemeName enum
+    pub fn theme_name(&self) -> crate::theme::ThemeName {
+        match self.tui.theme.as_str() {
+            "noir" => crate::theme::ThemeName::Noir,
+            "paper" => crate::theme::ThemeName::Paper,
+            "1977" => crate::theme::ThemeName::Retro1977,
+            "2077" => crate::theme::ThemeName::Cyber2077,
+            "matrix" => crate::theme::ThemeName::Matrix,
+            "sunset" => crate::theme::ThemeName::Sunset,
+            "arctic" => crate::theme::ThemeName::Arctic,
+            _ => crate::theme::ThemeName::Standard,
+        }
+    }
+
+    pub fn bg_density(&self) -> crate::theme::BgDensity {
+        match self.tui.background.as_str() {
+            "medium" => crate::theme::BgDensity::Medium,
+            "light" => crate::theme::BgDensity::Light,
+            "white" => crate::theme::BgDensity::White,
+            "terminal" => crate::theme::BgDensity::Transparent,
+            _ => crate::theme::BgDensity::Dark,
+        }
+    }
+}
+
+impl Default for SamConfig {
+    fn default() -> Self {
+        Self {
+            database: DatabaseConfig::default(),
+            tui: TuiConfig::default(),
+            fleet: FleetConfig::default(),
+            identity: IdentityConfig::default(),
+        }
+    }
+}
+
+/// Interactive setup wizard
+pub fn run_setup() -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::{self, Write};
+
+    println!("\n🛰️  S.A.M Mission Control — Setup Wizard\n");
+
+    let mut cfg = SamConfig::default();
+
+    // Database
+    println!("━━━ Database Configuration ━━━");
+    print!("  MySQL host [127.0.0.1]: ");
+    io::stdout().flush()?;
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    let host = input.trim();
+    cfg.database.host = Some(if host.is_empty() { "127.0.0.1".into() } else { host.into() });
+
+    input.clear();
+    print!("  MySQL port [3306]: ");
+    io::stdout().flush()?;
+    io::stdin().read_line(&mut input)?;
+    let port = input.trim();
+    cfg.database.port = Some(if port.is_empty() { 3306 } else { port.parse().unwrap_or(3306) });
+
+    input.clear();
+    print!("  MySQL user [root]: ");
+    io::stdout().flush()?;
+    io::stdin().read_line(&mut input)?;
+    let user = input.trim();
+    cfg.database.user = Some(if user.is_empty() { "root".into() } else { user.into() });
+
+    input.clear();
+    print!("  MySQL password: ");
+    io::stdout().flush()?;
+    io::stdin().read_line(&mut input)?;
+    cfg.database.password = Some(input.trim().into());
+
+    input.clear();
+    print!("  Database name [quantum_memory]: ");
+    io::stdout().flush()?;
+    io::stdin().read_line(&mut input)?;
+    let db = input.trim();
+    cfg.database.database = Some(if db.is_empty() { "quantum_memory".into() } else { db.into() });
+
+    // Identity
+    println!("\n━━━ Identity ━━━");
+    input.clear();
+    print!("  Your display name [operator]: ");
+    io::stdout().flush()?;
+    io::stdin().read_line(&mut input)?;
+    let name = input.trim();
+    cfg.identity.user = if name.is_empty() { "operator".into() } else { name.into() };
+
+    // Theme
+    println!("\n━━━ Theme ━━━");
+    println!("  Available: standard, noir, paper, 1977, 2077, matrix, sunset, arctic");
+    input.clear();
+    print!("  Default theme [standard]: ");
+    io::stdout().flush()?;
+    io::stdin().read_line(&mut input)?;
+    let theme = input.trim();
+    cfg.tui.theme = if theme.is_empty() { "standard".into() } else { theme.into() };
+
+    // Save
+    println!();
+    match cfg.save() {
+        Ok(_) => {
+            let path = dirs::config_dir().unwrap_or_default().join("sam/config.toml");
+            println!("✅ Config saved to {}", path.display());
+            println!("   Permissions set to 0600 (owner read/write only)");
+            println!("\n   Run `sam` to launch Mission Control.");
+        }
+        Err(e) => println!("❌ Failed to save config: {}", e),
+    }
+
+    Ok(())
+}
+
+/// Print fleet status to stdout (non-TUI)
+pub async fn print_status() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = crate::db::get_pool();
+    let agents = crate::db::load_fleet(&pool).await?;
+
+    println!("\n🛰️  S.A.M Fleet Status");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("{:<20} {:<12} {:<16} {}", "Agent", "Status", "Version", "IP");
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+    let mut online = 0;
+    for a in &agents {
+        let icon = match a.status.as_str() {
+            "online" => { online += 1; "●" },
+            "busy" => { online += 1; "◉" },
+            "offline" | "error" => "○",
+            _ => "?",
+        };
+        println!("{:<20} {} {:<9} {:<16} {}",
+            a.agent_name,
+            icon,
+            a.status,
+            a.oc_version.as_deref().unwrap_or("?"),
+            a.tailscale_ip.as_deref().unwrap_or("?"),
+        );
+    }
+
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("{}/{} online\n", online, agents.len());
+
+    pool.disconnect().await?;
+    Ok(())
+}
+
+/// Send a chat message and wait for response (non-TUI)
+pub async fn send_chat(agent: &str, message: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let pool = crate::db::get_pool();
+    let id = crate::db::send_direct(&pool, "cli", agent, message).await?;
+    println!("📨 Sent to @{}: {}", agent, message);
+    println!("   Message ID: {} — waiting for response...", id);
+
+    // Poll for response (max 30s)
+    for _ in 0..15 {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        if let Ok(msgs) = crate::db::load_agent_chat(&pool, agent, 1).await {
+            if let Some(m) = msgs.last() {
+                if m.id == id && m.status == "responded" {
+                    println!("↳ {}", m.response.as_deref().unwrap_or("(no response)"));
+                    pool.disconnect().await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    println!("⏳ Timed out after 30s — check `sam` TUI for response");
+    pool.disconnect().await?;
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
+mod cli;
 mod config;
 mod db;
 mod theme;
 
+use clap::Parser;
 use dotenvy;
 use crossterm::{
     event::{self, Event, KeyCode, KeyEventKind, MouseEvent, MouseEventKind, MouseButton},
@@ -745,10 +747,32 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = cli::Cli::parse();
+
+    // Load config (config.toml → .env → defaults)
+    let sam_config = cli::SamConfig::load(args.config.as_ref());
+    sam_config.apply_to_env();
+
+    // .env as fallback
     if dotenvy::dotenv().is_err() {
         if let Ok(home) = std::env::var("HOME") {
             let _ = dotenvy::from_path(std::path::Path::new(&home).join(".config/sam/.env"));
         }
+    }
+
+    // Handle subcommands
+    match args.command {
+        Some(cli::Commands::Setup) => { return cli::run_setup().map_err(|e| e.into()); }
+        Some(cli::Commands::Status) => { return cli::print_status().await.map_err(|e| e.into()); }
+        Some(cli::Commands::Chat { agent, message }) => {
+            let msg = message.join(" ");
+            return cli::send_chat(&agent, &msg).await.map_err(|e| e.into());
+        }
+        Some(cli::Commands::Version) => {
+            println!("sam v{}", env!("CARGO_PKG_VERSION"));
+            return Ok(());
+        }
+        None => {} // Launch TUI
     }
 
     let fleet_config = match config::load_fleet_config() {


### PR DESCRIPTION
Closes #15

## CLI Subcommands
- `sam` — launch TUI (default)
- `sam status` — print fleet status table to stdout
- `sam chat <agent> <msg>` — send message and wait for response (30s timeout)
- `sam setup` — interactive setup wizard (DB, identity, theme)
- `sam version` — print version

## Config File (`~/.config/sam/config.toml`)
- Database, TUI, fleet, and identity sections
- 0600 permissions on save
- Loading priority: --config flag → ./config.toml → ~/.config/sam/ → .env → defaults

## Theme Persistence
- `c`/`b` cycling saves to config.toml
- Restored on next launch

## Dependencies Added
- `clap` (derive) — argument parsing
- `dirs` — XDG config directory