### PR TITLE
feat: Agent provisioning wizard with SSH testing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod config;
+mod wizard;
 mod db;
 mod theme;
 
@@ -131,6 +132,8 @@ struct App {
     refresh_rx: Option<mpsc::UnboundedReceiver<ProbeResult>>,
     refreshing: bool,
     self_ip: String,
+    // Wizard
+    wizard: wizard::AgentWizard,
     // Task board
     tasks: Vec<db::Task>,
     task_selected: usize,
@@ -206,6 +209,7 @@ impl App {
             chat_input: String::new(), chat_history, chat_scroll: 0,
             agent_chat_input: String::new(), agent_chat_history: vec![], agent_chat_scroll: 0,
             refresh_rx: None, refreshing: false, self_ip,
+            wizard: wizard::AgentWizard::new(),
             tasks: vec![], task_selected: 0, task_input: String::new(), task_input_active: false,
             last_task_poll: Instant::now(),
             spinner_frame: 0, sort_mode: SortMode::Name,
@@ -1013,11 +1017,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             app.update_status_bar();
         }
 
-        terminal.draw(|f| match app.screen {
-            Screen::Dashboard => render_dashboard(f, &mut app),
-            Screen::AgentDetail => render_detail(f, &mut app),
-            Screen::TaskBoard => render_task_board(f, &app),
-            Screen::Help => render_help(f, &app),
+        terminal.draw(|f| {
+            match app.screen {
+                Screen::Dashboard => render_dashboard(f, &mut app),
+                Screen::AgentDetail => render_detail(f, &mut app),
+                Screen::TaskBoard => render_task_board(f, &app),
+                Screen::Help => render_help(f, &app),
+            }
+            if app.wizard.active {
+                wizard::render_wizard(f, &app.wizard, &app.theme, app.bg_density.bg());
+            }
         })?;
 
         if event::poll(Duration::from_millis(100))? {
@@ -1084,6 +1093,97 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             if let Event::Key(key) = ev {
                 if key.kind == KeyEventKind::Press {
+                    // Wizard overlay intercepts all input when active
+                    if app.wizard.active {
+                        match key.code {
+                            KeyCode::Esc => {
+                                if app.wizard.go_back() {
+                                    app.wizard.active = false;
+                                }
+                            }
+                            KeyCode::Enter => {
+                                let ready = app.wizard.advance();
+                                if ready {
+                                    // Create the agent
+                                    if let Some(pool) = &app.db_pool {
+                                        let w = &app.wizard;
+                                        let caps = format!(r#"["{}"]"#, w.location_str().to_lowercase());
+                                        let _ = pool.get_conn().await.map(|mut conn| {
+                                            let name = w.agent_name.clone();
+                                            let host = w.host.clone();
+                                            let loc = w.location_str().to_string();
+                                            let ssh = w.ssh_user.clone();
+                                            let emoji = w.emoji.clone();
+                                            let display = w.display_name.clone();
+                                            tokio::spawn(async move {
+                                                use mysql_async::prelude::*;
+                                                let _ = conn.exec_drop(
+                                                    "INSERT IGNORE INTO mc_fleet_status (agent_name, tailscale_ip, status, capabilities) VALUES (?, ?, 'offline', ?)",
+                                                    (&name, &host, &caps),
+                                                ).await;
+                                            });
+                                        });
+                                    }
+                                    // Add to fleet config in memory
+                                    app.fleet_config.push(config::AgentConfig {
+                                        name: app.wizard.agent_name.clone(),
+                                        display: Some(app.wizard.display_name.clone()),
+                                        emoji: Some(app.wizard.emoji.clone()),
+                                        location: Some(app.wizard.location_str().to_string()),
+                                        ssh_user: Some(app.wizard.ssh_user.clone()),
+                                    });
+                                    // Add to agents vec
+                                    app.agents.push(Agent {
+                                        name: app.wizard.display_name.clone(),
+                                        db_name: app.wizard.agent_name.clone(),
+                                        emoji: app.wizard.emoji.clone(),
+                                        host: app.wizard.host.clone(),
+                                        location: app.wizard.location_str().to_string(),
+                                        status: AgentStatus::Unknown,
+                                        os: String::new(), kernel: String::new(),
+                                        oc_version: String::new(), last_seen: String::new(),
+                                        current_task: None,
+                                        ssh_user: app.wizard.ssh_user.clone(),
+                                        capabilities: vec![],
+                                        token_burn: 0,
+                                    });
+                                    app.wizard.active = false;
+                                    app.status_message = format!("✅ Agent '{}' created", app.wizard.agent_name);
+                                }
+                            }
+                            KeyCode::Tab => {
+                                // Test SSH on confirm step
+                                if app.wizard.step == wizard::WizardStep::Confirm {
+                                    let host = app.wizard.host.clone();
+                                    let user = app.wizard.ssh_user.clone();
+                                    app.wizard.testing_ssh = true;
+                                    app.wizard.ssh_result = Some("Testing...".into());
+                                    let result = tokio::process::Command::new("ssh")
+                                        .args(["-o","ConnectTimeout=4","-o","StrictHostKeyChecking=no","-o","BatchMode=yes",
+                                            &format!("{}@{}", user, host), "hostname && openclaw --version 2>/dev/null || echo 'OC not found'"])
+                                        .output().await;
+                                    app.wizard.testing_ssh = false;
+                                    match result {
+                                        Ok(o) if o.status.success() => {
+                                            app.wizard.ssh_result = Some(format!("✅ {}", String::from_utf8_lossy(&o.stdout).trim()));
+                                        }
+                                        Ok(o) => {
+                                            app.wizard.ssh_result = Some(format!("❌ {}", String::from_utf8_lossy(&o.stderr).trim().chars().take(60).collect::<String>()));
+                                        }
+                                        Err(e) => {
+                                            app.wizard.ssh_result = Some(format!("❌ {}", e));
+                                        }
+                                    }
+                                } else {
+                                    // Tab = skip/advance
+                                    app.wizard.advance();
+                                }
+                            }
+                            KeyCode::Backspace => app.wizard.pop_char(),
+                            KeyCode::Char(ch) => app.wizard.push_char(ch),
+                            _ => {}
+                        }
+                    } else {
                     match app.screen {
                         Screen::Help => { app.screen = Screen::Dashboard; }
                         Screen::AgentDetail => match app.focus {
@@ -1168,6 +1268,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 KeyCode::Char('b') => app.cycle_bg(),
                                 KeyCode::Char('c') => app.cycle_theme(),
                                 KeyCode::Char('s') => app.cycle_sort(),
+                                KeyCode::Char('a') => { app.wizard.open(); }
                                 KeyCode::Char('t') => {
                                     app.screen = Screen::TaskBoard;
                                     app.last_task_poll = Instant::now() - Duration::from_secs(10);
@@ -1187,6 +1288,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         },
                     }
                 }
+                    }
             }
         }
 

--- a/src/wizard.rs
+++ b/src/wizard.rs
@@ -1,0 +1,310 @@
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+use crate::theme::Theme;
+
+#[derive(PartialEq, Clone)]
+pub enum WizardStep {
+    AgentName,
+    DisplayName,
+    Emoji,
+    Host,
+    SshUser,
+    Location,
+    Confirm,
+}
+
+impl WizardStep {
+    pub fn next(&self) -> Option<Self> {
+        match self {
+            Self::AgentName => Some(Self::DisplayName),
+            Self::DisplayName => Some(Self::Emoji),
+            Self::Emoji => Some(Self::Host),
+            Self::Host => Some(Self::SshUser),
+            Self::SshUser => Some(Self::Location),
+            Self::Location => Some(Self::Confirm),
+            Self::Confirm => None,
+        }
+    }
+
+    pub fn prev(&self) -> Option<Self> {
+        match self {
+            Self::AgentName => None,
+            Self::DisplayName => Some(Self::AgentName),
+            Self::Emoji => Some(Self::DisplayName),
+            Self::Host => Some(Self::Emoji),
+            Self::SshUser => Some(Self::Host),
+            Self::Location => Some(Self::SshUser),
+            Self::Confirm => Some(Self::Location),
+        }
+    }
+
+    pub fn index(&self) -> usize {
+        match self {
+            Self::AgentName => 0, Self::DisplayName => 1, Self::Emoji => 2,
+            Self::Host => 3, Self::SshUser => 4, Self::Location => 5, Self::Confirm => 6,
+        }
+    }
+
+    pub fn label(&self) -> &str {
+        match self {
+            Self::AgentName => "Agent Name",
+            Self::DisplayName => "Display Name",
+            Self::Emoji => "Emoji",
+            Self::Host => "Host (IP/hostname)",
+            Self::SshUser => "SSH User",
+            Self::Location => "Location",
+            Self::Confirm => "Confirm",
+        }
+    }
+}
+
+pub struct AgentWizard {
+    pub active: bool,
+    pub step: WizardStep,
+    pub agent_name: String,
+    pub display_name: String,
+    pub emoji: String,
+    pub host: String,
+    pub ssh_user: String,
+    pub location: usize, // index into LOCATIONS
+    pub error: Option<String>,
+    pub ssh_result: Option<String>,
+    pub testing_ssh: bool,
+}
+
+pub const LOCATIONS: &[&str] = &["Home", "SM", "VPS", "Mobile"];
+
+impl AgentWizard {
+    pub fn new() -> Self {
+        Self {
+            active: false,
+            step: WizardStep::AgentName,
+            agent_name: String::new(),
+            display_name: String::new(),
+            emoji: "🤖".into(),
+            host: String::new(),
+            ssh_user: "papasmurf".into(),
+            location: 0,
+            error: None,
+            ssh_result: None,
+            testing_ssh: false,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::new();
+    }
+
+    pub fn open(&mut self) {
+        self.reset();
+        self.active = true;
+    }
+
+    pub fn current_input(&self) -> &str {
+        match self.step {
+            WizardStep::AgentName => &self.agent_name,
+            WizardStep::DisplayName => &self.display_name,
+            WizardStep::Emoji => &self.emoji,
+            WizardStep::Host => &self.host,
+            WizardStep::SshUser => &self.ssh_user,
+            _ => "",
+        }
+    }
+
+    pub fn push_char(&mut self, c: char) {
+        self.error = None;
+        match self.step {
+            WizardStep::AgentName => self.agent_name.push(c),
+            WizardStep::DisplayName => self.display_name.push(c),
+            WizardStep::Emoji => { self.emoji.clear(); self.emoji.push(c); }
+            WizardStep::Host => self.host.push(c),
+            WizardStep::SshUser => self.ssh_user.push(c),
+            WizardStep::Location => {
+                // Cycle location with any key
+                self.location = (self.location + 1) % LOCATIONS.len();
+            }
+            _ => {}
+        }
+    }
+
+    pub fn pop_char(&mut self) {
+        match self.step {
+            WizardStep::AgentName => { self.agent_name.pop(); }
+            WizardStep::DisplayName => { self.display_name.pop(); }
+            WizardStep::Emoji => {}
+            WizardStep::Host => { self.host.pop(); }
+            WizardStep::SshUser => { self.ssh_user.pop(); }
+            _ => {}
+        }
+    }
+
+    pub fn advance(&mut self) -> bool {
+        // Validate current step
+        match self.step {
+            WizardStep::AgentName => {
+                let name = self.agent_name.trim().to_lowercase().replace(' ', "-");
+                if name.is_empty() { self.error = Some("Name required".into()); return false; }
+                self.agent_name = name;
+            }
+            WizardStep::Host => {
+                if self.host.trim().is_empty() { self.error = Some("Host/IP required".into()); return false; }
+            }
+            WizardStep::Confirm => return true, // Signal: ready to create
+            _ => {}
+        }
+
+        if let Some(next) = self.step.next() {
+            // Auto-fill display name if empty
+            if self.step == WizardStep::AgentName && self.display_name.is_empty() {
+                self.display_name = self.agent_name.clone();
+            }
+            self.step = next;
+        }
+        false
+    }
+
+    pub fn go_back(&mut self) -> bool {
+        if let Some(prev) = self.step.prev() {
+            self.step = prev;
+            self.error = None;
+            false
+        } else {
+            true // Signal: cancel wizard
+        }
+    }
+
+    pub fn location_str(&self) -> &str {
+        LOCATIONS[self.location]
+    }
+}
+
+pub fn render_wizard(frame: &mut Frame, wizard: &AgentWizard, t: &Theme, bg: Color) {
+    let area = frame.area();
+    // Center modal: 60% width, 70% height
+    let w = (area.width as f32 * 0.6) as u16;
+    let h = (area.height as f32 * 0.7) as u16;
+    let x = (area.width - w) / 2;
+    let y = (area.height - h) / 2;
+    let modal = Rect::new(x, y, w, h);
+
+    // Dim background
+    let dim = Block::default().style(Style::default().bg(Color::Rgb(5, 5, 10)));
+    frame.render_widget(dim, area);
+
+    // Modal frame
+    let inner = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(8), Constraint::Length(3)])
+        .split(modal);
+
+    // Header
+    let step_num = wizard.step.index() + 1;
+    let header = Paragraph::new(Line::from(vec![
+        Span::raw("  "),
+        Span::styled("🚀 New Agent", Style::default().fg(t.header_title).bold()),
+        Span::raw("    "),
+        Span::styled(format!("Step {}/7 — {}", step_num, wizard.step.label()), Style::default().fg(t.text_dim)),
+    ]))
+    .block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(t.border_active)).style(Style::default().bg(bg)));
+    frame.render_widget(header, inner[0]);
+
+    // Body
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(""));
+
+    // Progress bar
+    let steps = ["Name", "Display", "Emoji", "Host", "SSH", "Location", "✓"];
+    let progress: Vec<Span> = steps.iter().enumerate().map(|(i, s)| {
+        let style = if i < wizard.step.index() {
+            Style::default().fg(t.status_online)
+        } else if i == wizard.step.index() {
+            Style::default().fg(t.accent).bold()
+        } else {
+            Style::default().fg(t.text_dim)
+        };
+        let sep = if i < steps.len() - 1 { " → " } else { "" };
+        Span::styled(format!("{}{}", s, sep), style)
+    }).collect();
+    lines.push(Line::from(vec![Span::raw("  ")]).into());
+    lines.push(Line::from([vec![Span::raw("  ")], progress].concat()));
+    lines.push(Line::from(""));
+    lines.push(Line::from(""));
+
+    // Current field with all filled values
+    let fields = vec![
+        ("Agent Name", &wizard.agent_name, WizardStep::AgentName),
+        ("Display Name", &wizard.display_name, WizardStep::DisplayName),
+        ("Emoji", &wizard.emoji, WizardStep::Emoji),
+        ("Host", &wizard.host, WizardStep::Host),
+        ("SSH User", &wizard.ssh_user, WizardStep::SshUser),
+    ];
+
+    for (label, value, step) in &fields {
+        let is_current = *step == wizard.step;
+        let val_style = if is_current { Style::default().fg(t.accent).bold() } else { Style::default().fg(t.text) };
+        let label_style = if is_current { Style::default().fg(t.accent).bold() } else { Style::default().fg(t.text_dim) };
+        let cursor = if is_current { "▌" } else { "" };
+
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(format!("{:<14}", label), label_style),
+            Span::styled(if value.is_empty() { "(type here)" } else { value }, val_style),
+            Span::styled(cursor, Style::default().fg(t.accent)),
+        ]));
+    }
+
+    // Location (special — cycle with any key)
+    let is_loc = wizard.step == WizardStep::Location;
+    let loc_style = if is_loc { Style::default().fg(t.accent).bold() } else { Style::default().fg(t.text) };
+    let loc_label = if is_loc { Style::default().fg(t.accent).bold() } else { Style::default().fg(t.text_dim) };
+    lines.push(Line::from(vec![
+        Span::raw("    "),
+        Span::styled(format!("{:<14}", "Location"), loc_label),
+        Span::styled(format!("{} (press any key to cycle)", wizard.location_str()), loc_style),
+    ]));
+
+    lines.push(Line::from(""));
+
+    // Confirm step shows summary
+    if wizard.step == WizardStep::Confirm {
+        lines.push(Line::from(Span::styled("    ━━━ Ready to create ━━━", Style::default().fg(t.status_online).bold())));
+        lines.push(Line::from(Span::styled("    Press Enter to confirm, Esc to go back", Style::default().fg(t.text_dim))));
+
+        if let Some(result) = &wizard.ssh_result {
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::raw("    "),
+                Span::styled("SSH: ", Style::default().fg(t.text_bold).bold()),
+                Span::styled(result.as_str(), Style::default().fg(t.response)),
+            ]));
+        }
+    }
+
+    // Error
+    if let Some(err) = &wizard.error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::raw("    "),
+            Span::styled(format!("⚠️  {}", err), Style::default().fg(t.status_offline).bold()),
+        ]));
+    }
+
+    let body = Paragraph::new(lines)
+        .block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(t.border_active)).style(Style::default().bg(bg))
+            .padding(Padding::new(1, 1, 0, 0)));
+    frame.render_widget(body, inner[1]);
+
+    // Footer
+    let footer_text = match wizard.step {
+        WizardStep::Confirm => "Enter=create │ Esc=back │ Tab=test SSH",
+        _ => "Enter=next │ Esc=back/cancel │ Tab=skip",
+    };
+    let footer = Paragraph::new(Line::from(vec![
+        Span::raw("  "),
+        Span::styled(footer_text, Style::default().fg(t.text_dim)),
+    ])).block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(t.border)).style(Style::default().bg(bg)));
+    frame.render_widget(footer, inner[2]);
+}


### PR DESCRIPTION
Closes #16

## Agent Wizard (press `a` from dashboard)
- **7-step modal overlay**: name → display → emoji → host → SSH user → location → confirm
- **Progress bar** with step indicators
- **Validation** — name and host required, auto-fills display from name
- **SSH test** — Tab on confirm step tests connectivity + checks OpenClaw
- **Creates agent** in `mc_fleet_status` DB + adds to runtime fleet
- **Location selector** — cycles Home/SM/VPS/Mobile
- **Full theme support** — centered overlay dims background

## New Module
- `src/wizard.rs` — self-contained wizard state machine + renderer