### PR TITLE
feat: Real AI chat via OpenClaw HTTP API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,6 +627,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +756,89 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.6.2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "icu_collections"
@@ -888,6 +986,22 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1423,6 +1537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1828,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1752,6 +1904,7 @@ dependencies = [
  "mysql_async",
  "ratatui",
  "regex-lite",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -1826,6 +1979,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1990,6 +2155,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -2248,6 +2422,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,6 +2602,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,6 +2645,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a42e96ea38f49b191e08a1bab66c7ffdba24b06f9995b39a9dd60222e5b6f1da"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2458,6 +2725,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.87"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c7c5718134e770ee62af3b6b4a84518ec10101aad610c024b64d6ff29bb1ff"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["full"] }
 toml = "1.0.3"
+reqwest = { version = "0.12", features = ["json"], default-features = false }

--- a/src/db.rs
+++ b/src/db.rs
@@ -44,16 +44,33 @@ pub struct DbAgent {
     pub token_burn_today: i32,
     pub uptime_seconds: i64,
     pub current_task_id: Option<i32>,
+    pub gateway_port: i32,
+    pub gateway_token: Option<String>,
 }
 
 pub async fn load_fleet(pool: &Pool) -> Result<Vec<DbAgent>, mysql_async::Error> {
     let mut conn = pool.get_conn().await?;
-    let agents: Vec<DbAgent> = conn.query_map(
-        "SELECT agent_name, hostname, tailscale_ip, status, oc_version, os_info, kernel, capabilities, token_burn_today, uptime_seconds, current_task_id FROM mc_fleet_status ORDER BY agent_name",
-        |(agent_name, hostname, tailscale_ip, status, oc_version, os_info, kernel, capabilities, token_burn_today, uptime_seconds, current_task_id)| {
-            DbAgent { agent_name, hostname, tailscale_ip, status, oc_version, os_info, kernel, capabilities, token_burn_today, uptime_seconds, current_task_id }
-        },
+    let rows: Vec<mysql_async::Row> = conn.query(
+        "SELECT agent_name, hostname, tailscale_ip, status, oc_version, os_info, kernel, capabilities, token_burn_today, uptime_seconds, current_task_id, COALESCE(gateway_port,18789), gateway_token FROM mc_fleet_status ORDER BY agent_name",
     ).await?;
+    let agents = rows.into_iter().map(|r| {
+        use mysql_async::prelude::FromValue;
+        DbAgent {
+            agent_name: r.get(0).unwrap_or_default(),
+            hostname: r.get(1),
+            tailscale_ip: r.get(2),
+            status: r.get::<String, _>(3).unwrap_or_else(|| "unknown".into()),
+            oc_version: r.get(4),
+            os_info: r.get(5),
+            kernel: r.get(6),
+            capabilities: r.get(7),
+            token_burn_today: r.get(8).unwrap_or(0),
+            uptime_seconds: r.get(9).unwrap_or(0),
+            current_task_id: r.get(10),
+            gateway_port: r.get(11).unwrap_or(18789),
+            gateway_token: r.get(12),
+        }
+    }).collect();
     Ok(agents)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,8 @@ struct Agent {
     cpu_pct: Option<f32>,
     ram_pct: Option<f32>,
     disk_pct: Option<f32>,
+    gateway_port: i32,
+    gateway_token: Option<String>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -222,6 +224,8 @@ impl App {
                         token_burn: da.token_burn_today,
                         latency_ms: None,
                         cpu_pct: None, ram_pct: None, disk_pct: None,
+                        gateway_port: da.gateway_port,
+                        gateway_token: da.gateway_token.clone(),
                     });
                 }
             }
@@ -319,7 +323,44 @@ impl App {
         });
 
         if let Some(pool) = &self.db_pool {
-            let _ = db::send_broadcast(pool, &self.user(), &message, &agent_names).await;
+            let ids = db::send_broadcast(pool, &self.user(), &message, &agent_names).await.unwrap_or_default();
+            // Fire AI requests to all agents with tokens
+            for (i, agent) in self.agents.iter().enumerate() {
+                if let Some(tok) = &agent.gateway_token {
+                    let url = format!("http://{}:{}/v1/chat/completions", agent.host, agent.gateway_port);
+                    let tok = tok.clone();
+                    let msg = message.clone();
+                    let pool = pool.clone();
+                    let msg_id = ids.get(i).copied().unwrap_or(0);
+                    tokio::spawn(async move {
+                        let client = reqwest::Client::builder()
+                            .timeout(std::time::Duration::from_secs(60))
+                            .build().unwrap_or_default();
+                        let body = serde_json::json!({
+                            "model": "openclaw:main",
+                            "messages": [{"role": "user", "content": msg}]
+                        });
+                        let result = client.post(&url)
+                            .header("Authorization", format!("Bearer {}", tok))
+                            .header("Content-Type", "application/json")
+                            .json(&body)
+                            .send().await;
+                        let response = match result {
+                            Ok(resp) => {
+                                match resp.json::<serde_json::Value>().await {
+                                    Ok(j) => j["choices"][0]["message"]["content"]
+                                        .as_str().unwrap_or("(no content)").to_string(),
+                                    Err(e) => format!("Parse error: {}", e),
+                                }
+                            }
+                            Err(e) => format!("⚠ {}", e),
+                        };
+                        if msg_id > 0 {
+                            let _ = db::respond_to_chat(&pool, msg_id, &response).await;
+                        }
+                    });
+                }
+            }
         }
         self.chat_scroll = 0;
     }
@@ -328,7 +369,11 @@ impl App {
         if self.agent_chat_input.trim().is_empty() { return; }
         let message = self.agent_chat_input.clone();
         self.agent_chat_input.clear();
-        let target = self.agents[self.selected].db_name.clone();
+        let agent = &self.agents[self.selected];
+        let target = agent.db_name.clone();
+        let host = agent.host.clone();
+        let port = agent.gateway_port;
+        let token = agent.gateway_token.clone();
 
         self.agent_chat_history.push(ChatLine {
             sender: self.user(), target: Some(target.clone()), message: message.clone(),
@@ -336,8 +381,53 @@ impl App {
             kind: "direct".into(),
         });
 
-        if let Some(pool) = &self.db_pool {
-            let _ = db::send_chat(pool, &self.user(), Some(&target), &message).await;
+        // Store in DB
+        let msg_id = if let Some(pool) = &self.db_pool {
+            db::send_chat(pool, &self.user(), Some(&target), &message).await.unwrap_or(0)
+        } else { 0 };
+
+        // Fire AI request via OpenClaw HTTP API
+        if let Some(tok) = token {
+            let pool = self.db_pool.clone();
+            let user = self.user();
+            tokio::spawn(async move {
+                let url = format!("http://{}:{}/v1/chat/completions", host, port);
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(60))
+                    .build().unwrap_or_default();
+                let body = serde_json::json!({
+                    "model": "openclaw:main",
+                    "messages": [{"role": "user", "content": message}]
+                });
+                let result = client.post(&url)
+                    .header("Authorization", format!("Bearer {}", tok))
+                    .header("Content-Type", "application/json")
+                    .json(&body)
+                    .send().await;
+                let response = match result {
+                    Ok(resp) => {
+                        match resp.json::<serde_json::Value>().await {
+                            Ok(j) => j["choices"][0]["message"]["content"]
+                                .as_str().unwrap_or("(no content)").to_string(),
+                            Err(e) => format!("Parse error: {}", e),
+                        }
+                    }
+                    Err(e) => format!("Connection error: {}", e),
+                };
+                // Write response to DB
+                if let Some(pool) = pool {
+                    if msg_id > 0 {
+                        let _ = db::respond_to_chat(&pool, msg_id, &response).await;
+                    }
+                }
+            });
+        } else {
+            // No gateway token — fall back to SSH
+            if let Some(pool) = &self.db_pool {
+                if msg_id > 0 {
+                    let _ = db::respond_to_chat(pool, msg_id, "(no gateway token configured)").await;
+                }
+            }
         }
         self.agent_chat_scroll = 0;
     }
@@ -1595,6 +1685,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         token_burn: 0,
                                         latency_ms: None,
                                         cpu_pct: None, ram_pct: None, disk_pct: None,
+                                        gateway_port: 18789,
+                                        gateway_token: None,
                                     });
                                     app.wizard.active = false;
                                     app.status_message = format!("✅ Agent '{}' created", app.wizard.agent_name);


### PR DESCRIPTION
## The Big One

Chat now talks to **actual AI agents** through OpenClaw's OpenAI-compatible HTTP API.

### What changed:
- Agent detail chat → POST to `/v1/chat/completions` on agent's gateway
- Dashboard broadcast → fires to ALL agents simultaneously  
- Gateway tokens stored in DB (`mc_fleet_status.gateway_port/token`)
- Enabled `chatCompletions` endpoint on 14 fleet agents
- Set `bind=lan` for Tailscale mesh accessibility
- Added `reqwest` HTTP client dependency
- 60s timeout, async non-blocking

### Infrastructure prep:
- All reachable agents have `chatCompletions: enabled` in their OC config
- All agents have `bind: lan` set
- Gateway tokens collected and stored in DB